### PR TITLE
Add `.spec` file and Service Commander definition

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -37,12 +37,32 @@ jobs:
     - name: List target directory
       run: ls -l target
 
-    - name: Copy dist artifacts to staging directory
-      run: mkdir staging && cp target/*with-dependencies.jar staging/mapepire-server-${{ env.project_version }}.jar
+    - name: create jt400 pseudo-directory
+      run: sudo mkdir -p /QIBM/ProdData/OS400/jt400/lib/
+    - name: change ownership of jt400 psudo-directory
+      run: sudo chown $USER /QIBM/ProdData/OS400/jt400/lib/
+    - name: fetch jt400.jar
+      run: sudo curl https://repo1.maven.org/maven2/net/sf/jt400/jt400/10.7/jt400-10.7.jar -o /QIBM/ProdData/OS400/jt400/lib/jt400.jar
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+    - name: create staging directory
+      run: |
+        mkdir -p staging/opt/mapepire/lib/
+        mkdir -p staging/opt/mapepire/bin/
+    - name: Populate staging directory
+      run: |
+        mv scripts/mapepire-start.sh staging/opt/mapepire/bin/mapepire
+        mv target/mapepire-server-${{ env.project_version }}-jar-with-dependencies.jar staging/opt/mapepire/lib/mapepire.jar
+
+    - name: Create distribution .zip
+      run: |
+        pushd staging/opt/
+        zip -r ../../mapepire-server-${{ env.project_version }}.zip mapepire
+        popd
 
     - name: Create the tag and release
       uses: softprops/action-gh-release@v1
       with:
         tag_name: v${{ env.project_version }}
         name: v${{ env.project_version }}
-        files: staging/codeforiserver-${{ env.project_version }}.jar
+        files: mapepire-server-${{ env.project_version }}.zip

--- a/.github/workflows/zip_dist_ci.yaml
+++ b/.github/workflows/zip_dist_ci.yaml
@@ -1,0 +1,59 @@
+name: Zip dist CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  remote_build_dir: /home/${{ secrets.IBMI_USER }}/build/${{ github.sha }}/
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+        cache: maven
+        
+    - name: Get Maven project version
+      run: |
+        echo "project_version=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:3.1.0:exec  --file pom.xml)" >> $GITHUB_ENV
+        cat $GITHUB_ENV
+
+    - name: create jt400 psudo-directory
+      run: sudo mkdir -p /QIBM/ProdData/OS400/jt400/lib/
+    - name: change ownership of jt400 psudo-directory
+      run: sudo chown $USER /QIBM/ProdData/OS400/jt400/lib/
+    - name: fetch jt400.jar
+      run: sudo curl https://repo1.maven.org/maven2/net/sf/jt400/jt400/10.7/jt400-10.7.jar -o /QIBM/ProdData/OS400/jt400/lib/jt400.jar
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+    - name: create staging directory
+      run: |
+        mkdir -p staging/opt/mapepire/lib/
+        mkdir -p staging/opt/mapepire/bin/
+    - name: Populate staging directory
+      run: |
+        mv scripts/mapepire-start.sh staging/opt/mapepire/bin/mapepire
+        mv target/mapepire-server-${{ env.project_version }}-jar-with-dependencies.jar staging/opt/mapepire/lib/mapepire.jar
+
+    - name: Create distribution .zip
+      run: |
+        pushd staging/opt/
+        zip -r ../../mapepire-server-${{ env.project_version }}.zip mapepire
+        popd
+
+    - name: Upload dist artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: mapepire-server-${{ env.project_version }}.zip
+        path: mapepire-server-${{ env.project_version }}.zip
+            

--- a/scripts/mapepire-start.sh
+++ b/scripts/mapepire-start.sh
@@ -1,0 +1,2 @@
+#!/QOpenSys/pkgs/bin/bash
+exec /QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java -jar /opt/mapepire-server/lib/mapepire-server.jar

--- a/service-commander-def.yaml
+++ b/service-commander-def.yaml
@@ -1,0 +1,7 @@
+name: Mapepire Server
+dir: /opt/mapepire/bin
+start_cmd: mapepire
+check_alive: mapepire,8076
+batch_mode: 'false'
+environment_vars:
+- PATH=/QOpenSys/pkgs/bin:/QOpenSys/usr/bin:/usr/ccs/bin:/QOpenSys/usr/bin/X11:/usr/sbin:.:/usr/bin


### PR DESCRIPTION
Spec file needs to be run like so:

```fortran
time rpmbuild --define "_builddir `pwd`" --define 'mversion ${{ env.project_version }}' -ba mapepire-server.spec
```

Remaining tasks:
- [ ] Modify release CI to build RPM
- [ ] Create mapepire-stop script (could just require/use `sc`)
- [ ] Update main documentation with RPM steps
- [ ] Update main documentation with non-RPM steps
