### PR TITLE
Deploy server to `OSSBUILD` on release

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -79,6 +79,7 @@ jobs:
           --rcwd "/home/${{ secrets.IBMI_USER }}" \
           --cmd "mkdir -p /opt/download" \
           --rcwd "/opt/download" \
+          --cmd "rm -f mapepire-server-dist.zip" \
           --cmd "wget -O mapepire-server-dist.zip https://github.com/Mapepire-IBMi/mapepire-server/releases/download/v${{ env.project_version }}/mapepire-server-${{ env.project_version }}.zip" \
           --cmd "mkdir -p /opt/mapepire" \
           --rcwd "/opt/mapepire" \

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -39,18 +39,23 @@ jobs:
     - name: List target directory
       run: ls -l target
 
-    - name: create jt400 pseudo-directory
+    - name: Create jt400 pseudo-directory
       run: sudo mkdir -p /QIBM/ProdData/OS400/jt400/lib/
-    - name: change ownership of jt400 psudo-directory
+
+    - name: Change ownership of jt400 psudo-directory
       run: sudo chown $USER /QIBM/ProdData/OS400/jt400/lib/
-    - name: fetch jt400.jar
+
+    - name: Fetch jt400.jar
       run: sudo curl https://repo1.maven.org/maven2/net/sf/jt400/jt400/10.7/jt400-10.7.jar -o /QIBM/ProdData/OS400/jt400/lib/jt400.jar
+
     - name: Build with Maven
       run: mvn -B package --file pom.xml
-    - name: create staging directory
+
+    - name: Create staging directory
       run: |
         mkdir -p staging/opt/mapepire/lib/mapepire/
         mkdir -p staging/opt/mapepire/bin/
+
     - name: Populate staging directory
       run: |
         mv scripts/mapepire-start.sh staging/opt/mapepire/bin/mapepire
@@ -77,17 +82,17 @@ jobs:
       run: | 
         ici \
           --rcwd "/home/${{ secrets.IBMI_USER }}" \
-          --cmd "mkdir -p /opt/download" \
-          --rcwd "/opt/download" \
+          --cmd "mkdir -p /opt/download/release" \
+          --rcwd "/opt/download/release" \
           --cmd "rm -f mapepire-server-dist.zip" \
           --cmd "wget -O mapepire-server-dist.zip https://github.com/Mapepire-IBMi/mapepire-server/releases/download/v${{ env.project_version }}/mapepire-server-${{ env.project_version }}.zip" \
-          --cmd "mkdir -p /opt/mapepire" \
-          --rcwd "/opt/mapepire" \
-          --cmd "jar xvf /opt/download/mapepire-server-dist.zip" \
+          --cmd "mkdir -p /opt/mapepire/release" \
+          --rcwd "/opt/mapepire/release" \
+          --cmd "jar xvf /opt/download/release/mapepire-server-dist.zip" \
           --cmd "chown -R qsys ." \
-          --rcwd "/opt/mapepire/lib/mapepire" \
+          --rcwd "/opt/mapepire/release/lib/mapepire" \
           --cmd "sc check mapepire.yaml" \
-          --ignore --cmd "sc stop mapepire.yaml" \
+          --cmd "sc stop mapepire.yaml" \
           --cmd "sc start mapepire.yaml" \
       env:
         IBMI_HOST: ${{ secrets.IBMI_HOST }}

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -86,7 +86,7 @@ jobs:
           --cmd "jar xvf /opt/download/mapepire-server-dist.zip" \
           --cmd "chown -R qsys ." \
           --rcwd "/opt/mapepire/lib/mapepire" \
-          --ignore --cmd "sc check mapepire.yaml" \
+          --cmd "sc check mapepire.yaml" \
           --ignore --cmd "sc stop mapepire.yaml" \
           --cmd "sc start mapepire.yaml" \
       env:

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -91,10 +91,10 @@ jobs:
           --cmd "rm -f bin lib" \
           --cmd "jar xvf /opt/download/release/mapepire-server-dist.zip" \
           --cmd "chown -R qsys ." \
-          --rcwd "/opt/mapepire/release/lib/mapepire" \
-          --cmd "sc check mapepire.yaml" \
-          --cmd "sc stop mapepire.yaml" \
-          --cmd "sc start mapepire.yaml" \
+          --cmd "ln -sf /opt/mapepire/release/lib/mapepire/mapepire.yaml /QOpenSys/etc/sc/services/mapepire.yaml" \
+          --cmd "sc check mapepire" \
+          --cmd "sc stop mapepire" \
+          --cmd "sc start mapepire" \
       env:
         IBMI_HOST: ${{ secrets.IBMI_HOST }}
         IBMI_USER: ${{ secrets.IBMI_USER }}

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -9,6 +9,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    environment: OSSBUILD
+
     steps:
     - uses: actions/checkout@v3
       name: Check out
@@ -67,3 +69,27 @@ jobs:
         tag_name: v${{ env.project_version }}
         name: v${{ env.project_version }}
         files: mapepire-server-${{ env.project_version }}.zip
+
+    - name: Install NPM Dependencies
+      run: npm i -g @ibm/ibmi-ci
+
+    - name: Deploy Server to IBM i
+      run: | 
+        ici \
+          --rcwd "/home/${{ secrets.IBMI_USER }}" \
+          --cmd "mkdir -p /opt/download" \
+          --rcwd "/opt/download" \
+          --cmd "wget -O mapepire-server-dist.zip https://github.com/Mapepire-IBMi/mapepire-server/releases/download/v${{ env.project_version }}/mapepire-server-${{ env.project_version }}.zip" \
+          --cmd "mkdir -p /opt/mapepire" \
+          --rcwd "/opt/mapepire" \
+          --cmd "jar xvf /opt/download/mapepire-server-dist.zip" \
+          --cmd "chown -R qsys ." \
+          --rcwd "/opt/mapepire/lib/mapepire" \
+          --ignore --cmd "sc check mapepire.yaml" \
+          --ignore --cmd "sc stop mapepire.yaml" \
+          --cmd "sc start mapepire.yaml" \
+      env:
+        IBMI_HOST: ${{ secrets.IBMI_HOST }}
+        IBMI_USER: ${{ secrets.IBMI_USER }}
+        IBMI_PASSWORD: ${{ secrets.IBMI_PASSWORD }}
+        IBMI_SSH_PORT: ${{ secrets.IBMI_SSH_PORT }}

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -88,6 +88,7 @@ jobs:
           --cmd "wget -O mapepire-server-dist.zip https://github.com/Mapepire-IBMi/mapepire-server/releases/download/v${{ env.project_version }}/mapepire-server-${{ env.project_version }}.zip" \
           --cmd "mkdir -p /opt/mapepire/release" \
           --rcwd "/opt/mapepire/release" \
+          --cmd "rm -f bin lib" \
           --cmd "jar xvf /opt/download/release/mapepire-server-dist.zip" \
           --cmd "chown -R qsys ." \
           --rcwd "/opt/mapepire/release/lib/mapepire" \

--- a/.github/workflows/zip_dist_ci.yaml
+++ b/.github/workflows/zip_dist_ci.yaml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  remote_build_dir: /home/${{ secrets.IBMI_USER }}/build/${{ github.sha }}/
-
 jobs:
   build:
 
@@ -28,33 +25,60 @@ jobs:
         echo "project_version=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:3.1.0:exec  --file pom.xml)" >> $GITHUB_ENV
         cat $GITHUB_ENV
 
-    - name: create jt400 psudo-directory
+    - name: Create jt400 psudo-directory
       run: sudo mkdir -p /QIBM/ProdData/OS400/jt400/lib/
-    - name: change ownership of jt400 psudo-directory
+
+    - name: Change ownership of jt400 psudo-directory
       run: sudo chown $USER /QIBM/ProdData/OS400/jt400/lib/
-    - name: fetch jt400.jar
+
+    - name: Fetch jt400.jar
       run: sudo curl https://repo1.maven.org/maven2/net/sf/jt400/jt400/10.7/jt400-10.7.jar -o /QIBM/ProdData/OS400/jt400/lib/jt400.jar
+
     - name: Build with Maven
       run: mvn -B package --file pom.xml
-    - name: create staging directory
+
+    - name: Create staging directory
       run: |
         mkdir -p staging/opt/mapepire/lib/mapepire/
         mkdir -p staging/opt/mapepire/bin/
+
+    - name: Update service commander definition
+      run : |
+        sed -i 's/name: .*/name: Mapepire Development Server/; s/check_alive: .*/check_alive: mapepiredev,8075/' service-commander-def.yaml
+
     - name: Populate staging directory
       run: |
         mv scripts/mapepire-start.sh staging/opt/mapepire/bin/mapepire
         mv target/mapepire-server-${{ env.project_version }}-jar-with-dependencies.jar staging/opt/mapepire/lib/mapepire/mapepire-server.jar
-        mv service-commander-def.yaml staging/opt/mapepire/lib/mapepire/mapepire.yaml
-
-    - name: Create distribution .zip
-      run: |
-        pushd staging/opt/mapepire
-        zip -r ../../../mapepire-server-${{ env.project_version }}.zip bin lib
-        popd
+        mv service-commander-def.yaml staging/opt/mapepire/lib/mapepire/mapepiredev.yaml
 
     - name: Upload dist artifact
       uses: actions/upload-artifact@v4
+      id: artifact-upload
       with:
-        name: mapepire-server-${{ env.project_version }}.zip
-        path: mapepire-server-${{ env.project_version }}.zip
+        name: mapepire-server-${{ env.project_version }}
+        path: staging/opt/mapepire
+        if-no-files-found: error
             
+    - name: Deploy Server to IBM i
+      if: github.event_name == 'push'
+      run: | 
+        ici \
+          --rcwd "/home/${{ secrets.IBMI_USER }}" \
+          --cmd "mkdir -p /opt/download/dev" \
+          --rcwd "/opt/download/dev" \
+          --cmd "rm -f mapepire-server-dist.zip" \
+          --cmd "wget -O mapepire-server-dist.zip ${{ steps.artifact-upload.outputs.artifact-url }}" \
+          --cmd "mkdir -p /opt/mapepire/dev" \
+          --rcwd "/opt/mapepire/dev" \
+          --cmd "jar xvf /opt/download/dev/mapepire-server-dist.zip" \
+          --cmd "chown -R qsys ." \
+          --rcwd "/opt/mapepire/dev/lib/mapepire" \
+          --cmd "sc check mapepiredev.yaml" \
+          --cmd "sc stop mapepiredev.yaml" \
+          --cmd "sc start mapepiredev.yaml" \
+      env:
+        IBMI_HOST: ${{ secrets.IBMI_HOST }}
+        IBMI_USER: ${{ secrets.IBMI_USER }}
+        IBMI_PASSWORD: ${{ secrets.IBMI_PASSWORD }}
+        IBMI_SSH_PORT: ${{ secrets.IBMI_SSH_PORT }}

--- a/.github/workflows/zip_dist_ci.yaml
+++ b/.github/workflows/zip_dist_ci.yaml
@@ -68,7 +68,7 @@ jobs:
           --cmd "mkdir -p /opt/download/dev" \
           --rcwd "/opt/download/dev" \
           --cmd "rm -f mapepire-server-dist.zip" \
-          --cmd "wget -O mapepire-server-dist.zip ${{ steps.artifact-upload.outputs.artifact-url }}" \
+          --cmd "wget --header="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -O mapepire-server-dist.zip ${{ steps.artifact-upload.outputs.artifact-url }}" \
           --cmd "mkdir -p /opt/mapepire/dev" \
           --rcwd "/opt/mapepire/dev" \
           --cmd "rm -f bin lib" \

--- a/.github/workflows/zip_dist_ci.yaml
+++ b/.github/workflows/zip_dist_ci.yaml
@@ -71,6 +71,7 @@ jobs:
           --cmd "wget -O mapepire-server-dist.zip ${{ steps.artifact-upload.outputs.artifact-url }}" \
           --cmd "mkdir -p /opt/mapepire/dev" \
           --rcwd "/opt/mapepire/dev" \
+          --cmd "rm -f bin lib" \
           --cmd "jar xvf /opt/download/dev/mapepire-server-dist.zip" \
           --cmd "chown -R qsys ." \
           --rcwd "/opt/mapepire/dev/lib/mapepire" \

--- a/.github/workflows/zip_dist_ci.yaml
+++ b/.github/workflows/zip_dist_ci.yaml
@@ -74,10 +74,10 @@ jobs:
           --cmd "rm -f bin lib" \
           --cmd "jar xvf /opt/download/dev/mapepire-server-dist.zip" \
           --cmd "chown -R qsys ." \
-          --rcwd "/opt/mapepire/dev/lib/mapepire" \
-          --cmd "sc check mapepiredev.yaml" \
-          --cmd "sc stop mapepiredev.yaml" \
-          --cmd "sc start mapepiredev.yaml" \
+          --cmd "ln -sf /opt/mapepire/dev/lib/mapepire/mapepiredev.yaml /QOpenSys/etc/sc/services/mapepiredev.yaml" \
+          --cmd "sc check mapepiredev" \
+          --cmd "sc stop mapepiredev" \
+          --cmd "sc start mapepiredev" \
       env:
         IBMI_HOST: ${{ secrets.IBMI_HOST }}
         IBMI_USER: ${{ secrets.IBMI_USER }}


### PR DESCRIPTION
### Changes
Automatically deploy mapepire server to `OSSBUILD` on release. This will help ensure that our client test workflows are running against the latest release.

@ThePrez @worksofliam I don't have access to the settings, so can you add the following environment secrets:
- [ ] `OSSBUILD` environment
  - [ ] `IBMI_HOST`
  - [ ] `IBMI_USER`
  - [ ] `IBMI_PASSWORD`
  - [ ] `IBMI_SSH_PORT`