### PR TITLE
Trace enhancements and Rework management of server-side certificates

### DIFF
--- a/src/main/java/com/github/ibm/mapepire/MapepireServer.java
+++ b/src/main/java/com/github/ibm/mapepire/MapepireServer.java
@@ -10,12 +10,14 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.server.NativeWebSocketServletContainerInitializer;
 import org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter;
+
+import com.github.ibm.mapepire.Tracer.Dest;
+import com.github.ibm.mapepire.Tracer.TraceLevel;
 import com.github.ibm.mapepire.certstuff.ServerCertGetter;
 import com.github.ibm.mapepire.certstuff.ServerCertInfo;
 import com.github.ibm.mapepire.ws.DbSocketCreator;
 import com.github.theprez.jcmdutils.AppLogger;
 import com.github.theprez.jcmdutils.StringUtils;
-import com.github.theprez.jcmdutils.StringUtils.TerminalColor;
 
 public class MapepireServer {
     private static Server server;

--- a/src/main/java/com/github/ibm/mapepire/MapepireServer.java
+++ b/src/main/java/com/github/ibm/mapepire/MapepireServer.java
@@ -43,8 +43,19 @@ public class MapepireServer {
 
                 io.run();
             } else {
+                Tracer.get().setDest(Dest.FILE);
+                if(args.remove("--traceErrors")) {
+                    Tracer.get().setTraceLevel(TraceLevel.ERRORS);
+                }
+                if(args.remove("--traceOn")) {
+                    Tracer.get().setTraceLevel(TraceLevel.ON);
+                }
+                if(args.remove("--traceDs")) {
+                    Tracer.get().setTraceLevel(TraceLevel.DATASTREAM);
+                }
                 AppLogger logger = AppLogger.getSingleton(args.remove("-v"));
                 logger.printf("Starting daemon...");
+                Tracer.info("Starting daemon...");
                 DbSocketCreator.enableDaemon();
                 
                 server = new Server();

--- a/src/main/java/com/github/ibm/mapepire/certstuff/SelfSignedCertGenerator.java
+++ b/src/main/java/com/github/ibm/mapepire/certstuff/SelfSignedCertGenerator.java
@@ -62,7 +62,7 @@ public class SelfSignedCertGenerator {
         stderrLogger.join();
         stdoutLogger.join();
 
-        return new ServerCertInfo(_keyStore, _storePassword, _keyPassword, _alias);
+        return new ServerCertJKS(_keyStore, _storePassword, _keyPassword, _alias);
     }
 
     private class StreamLogger extends Thread {

--- a/src/main/java/com/github/ibm/mapepire/certstuff/ServerCertGetter.java
+++ b/src/main/java/com/github/ibm/mapepire/certstuff/ServerCertGetter.java
@@ -2,55 +2,105 @@ package com.github.ibm.mapepire.certstuff;
 
 import java.io.File;
 import java.io.IOException;
-
+import java.net.InetAddress;
+import java.util.LinkedList;
 import com.github.ibm.mapepire.Tracer;
+import com.github.theprez.jcmdutils.StringUtils;
 
 public class ServerCertGetter {
 
     private static class StoreDefaults {
-        private static String STORE_PASS = "hyrule";
-        private static String KEY_PASS = "hyrule";
-        public static String ALIAS = "wsdb";
+        private static String STORE_PASS = "mapepire";
+        private static String KEY_PASS = "mapepire";
+        public static String ALIAS = "mapepire";
 
         public static String getStorePass() {
-            String envVar = System.getenv("WSDB_STORE_PASS");
-            if (envVar != null)
+            String envVar = System.getenv("MAPEPIRE_STORE_PASS");
+            if (StringUtils.isNonEmpty(envVar))
                 return envVar;
             else
                 return StoreDefaults.STORE_PASS;
         }
 
         public static String getKeyPass() {
-            String envVar = System.getenv("WSDB_KEY_PASS");
-            if (envVar != null)
+            String envVar = System.getenv("MAPEPIRE_KEY_PASS");
+            if (StringUtils.isNonEmpty(envVar))
                 return envVar;
             else
                 return StoreDefaults.KEY_PASS;
         }
+
+        public static String getAlias() {
+            String envVar = System.getenv("MAPEPIRE_ALIAS");
+            if (StringUtils.isNonEmpty(envVar))
+                return envVar;
+            else
+                return StoreDefaults.ALIAS;
+        }
     }
 
-    private final File m_userCertFile; 
+    private final ServerCertLetsEncrypt m_letsEncrypt;
     private final File m_defaultCertFile;
+    private final File m_userCertFile;
 
     public ServerCertGetter() {
         final File userHomeDir = new File(System.getProperty("user.home"));
-        final File dotDir = new File(userHomeDir, ".wsdb");
+        final File dotDir = new File(userHomeDir, ".mapepire");
         dotDir.mkdirs();
-        m_userCertFile = new File(dotDir, "user.jks");
+        m_letsEncrypt = ServerCertLetsEncrypt.get(findLetsEncryptCertDir());
+        m_userCertFile = new File ("/QOpenSys/etc/mapepire/cert/server.jks");
         m_defaultCertFile = new File(dotDir, "default.jks");
     }
 
+    private File findLetsEncryptCertDir() {
+        File liveDir = new File("/etc/letsencrypt/live");
+        if (!liveDir.isDirectory()) {
+            return null;
+        }
+        LinkedList<File> candidates = new LinkedList<File>();
+        for (File ls : liveDir.listFiles()) {
+            if (ls.isDirectory()) {
+                candidates.add(ls);
+            }
+        }
+        if (candidates.isEmpty()) {
+            return null;
+        }
+        if (1 == candidates.size()) {
+            return candidates.removeFirst();
+        }
+
+        try {
+            String myHostName = InetAddress.getLocalHost().getCanonicalHostName().toLowerCase();
+            Tracer.info("------we think our hostname is "+myHostName);
+            for (File candidate : candidates) {
+                if (candidate.getName().equalsIgnoreCase(myHostName)) {
+                    return candidate;
+                }
+            }
+
+        } catch (IOException e) {
+        }
+        return candidates.removeLast();
+    }
+
     public ServerCertInfo get() throws IOException, InterruptedException {
-        if(m_userCertFile.isFile()) {
-            Tracer.info("Using user-defined certificate file "+m_userCertFile.getAbsolutePath());
-            return new ServerCertInfo(m_userCertFile, StoreDefaults.getStorePass(), StoreDefaults.getKeyPass(), StoreDefaults.ALIAS);
-        } else if(m_defaultCertFile.isFile()) {
-            Tracer.info("Reusing previously-generated default certificate in "+m_defaultCertFile.getAbsolutePath());
-            return new ServerCertInfo(m_defaultCertFile, StoreDefaults.getStorePass(), StoreDefaults.getKeyPass(), StoreDefaults.ALIAS);
-        } else  {
+        if (m_userCertFile.isFile()) {
+            Tracer.info("Reusing user-defined server certificate in " + m_defaultCertFile.getAbsolutePath());
+            return new ServerCertJKS(m_defaultCertFile, StoreDefaults.getStorePass(), StoreDefaults.getKeyPass(),
+                    StoreDefaults.getAlias());
+        } else if (null != m_letsEncrypt) {
+            Tracer.info("Using LetsEncrypt certificate file " + m_letsEncrypt.getKeyStoreFile().getAbsolutePath());
+            return m_letsEncrypt;
+        } else if (m_defaultCertFile.isFile()) {
+            Tracer.info("Reusing previously-generated default certificate in " + m_defaultCertFile.getAbsolutePath());
+            return new ServerCertJKS(m_defaultCertFile, StoreDefaults.getStorePass(), StoreDefaults.getKeyPass(),
+                    StoreDefaults.getAlias());
+        } else {
             Tracer.warn("Generating self-signed certificate");
             final SelfSignedCertGenerator gen = new SelfSignedCertGenerator();
-            return gen.generate(StoreDefaults.getStorePass(), StoreDefaults.getKeyPass(), m_defaultCertFile, StoreDefaults.ALIAS);
+            return gen.generate(StoreDefaults.getStorePass(), StoreDefaults.getKeyPass(), m_defaultCertFile,
+                    StoreDefaults.getAlias());
         }
     }
 }

--- a/src/main/java/com/github/ibm/mapepire/certstuff/ServerCertInfo.java
+++ b/src/main/java/com/github/ibm/mapepire/certstuff/ServerCertInfo.java
@@ -1,7 +1,6 @@
 package com.github.ibm.mapepire.certstuff;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.KeyStore;
@@ -9,44 +8,15 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 
-public class ServerCertInfo {
+public interface ServerCertInfo {
 
-    private final String m_storePass;
-    private final File m_storePath;
-    private KeyStore m_keystore = null;
-    private final String m_keyPass;
-    private final String m_alias;
+    public KeyStore getKeyStore() throws KeyStoreException, NoSuchAlgorithmException, FileNotFoundException, IOException, CertificateException, InterruptedException;
 
-    public ServerCertInfo(final File _keyStore, final String _storePassword, final String _keyPassword, final String _alias) {
-        m_storePath = _keyStore;
-        m_storePass = _storePassword;
-        m_keyPass = _keyPassword;
-        m_alias = _alias;
-    }
+    public String getAlias();
 
-    public KeyStore getKeyStore() throws KeyStoreException, NoSuchAlgorithmException,
-            FileNotFoundException, IOException, CertificateException {
-        if (null != m_keystore) {
-            return m_keystore;
-        }
-        final KeyStore ks = KeyStore.getInstance("JKS");
-        ks.load(new FileInputStream(m_storePath), m_storePass.toCharArray());
-        return m_keystore = ks;
-    }
+    public String getStorePass() ;
 
-    public String getAlias() {
-        return m_alias;
-    }
+    public String getKeyPass();
 
-    public String getStorePass() {
-        return m_storePass;
-    }
-
-    public String getKeyPass() {
-        return m_keyPass;
-    }
-
-    public File getKeyStoreFile() {
-        return m_storePath;
-    }
+    public File getKeyStoreFile();
 }

--- a/src/main/java/com/github/ibm/mapepire/certstuff/ServerCertJKS.java
+++ b/src/main/java/com/github/ibm/mapepire/certstuff/ServerCertJKS.java
@@ -1,0 +1,52 @@
+package com.github.ibm.mapepire.certstuff;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+
+public class ServerCertJKS implements ServerCertInfo {
+
+    private final String m_storePass;
+    private final File m_storePath;
+    private KeyStore m_keystore = null;
+    private final String m_keyPass;
+    private final String m_alias;
+
+    public ServerCertJKS(final File _keyStore, final String _storePassword, final String _keyPassword, final String _alias) {
+        m_storePath = _keyStore;
+        m_storePass = _storePassword;
+        m_keyPass = _keyPassword;
+        m_alias = _alias;
+    }
+
+    public KeyStore getKeyStore() throws KeyStoreException, NoSuchAlgorithmException,
+            FileNotFoundException, IOException, CertificateException {
+        if (null != m_keystore) {
+            return m_keystore;
+        }
+        final KeyStore ks = KeyStore.getInstance("JKS");
+        ks.load(new FileInputStream(m_storePath), m_storePass.toCharArray());
+        return m_keystore = ks;
+    }
+
+    public String getAlias() {
+        return m_alias;
+    }
+
+    public String getStorePass() {
+        return m_storePass;
+    }
+
+    public String getKeyPass() {
+        return m_keyPass;
+    }
+
+    public File getKeyStoreFile() {
+        return m_storePath;
+    }
+}

--- a/src/main/java/com/github/ibm/mapepire/certstuff/ServerCertLetsEncrypt.java
+++ b/src/main/java/com/github/ibm/mapepire/certstuff/ServerCertLetsEncrypt.java
@@ -1,0 +1,24 @@
+package com.github.ibm.mapepire.certstuff;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+public class ServerCertLetsEncrypt extends ServerCertPEM {
+
+    public ServerCertLetsEncrypt(File _dir) throws FileNotFoundException {
+        super(new File(_dir, "fullchain.pem"), new File(_dir, "privkey.pem"));
+    }
+    public static ServerCertLetsEncrypt get(File _dir) {
+        if(null == _dir) {
+            return null;
+        }
+        try{
+            ServerCertLetsEncrypt ret = new ServerCertLetsEncrypt(_dir);
+            ret.getKeyStore();
+            return ret;
+        }catch(Exception _e) {
+            _e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/github/ibm/mapepire/certstuff/ServerCertPEM.java
+++ b/src/main/java/com/github/ibm/mapepire/certstuff/ServerCertPEM.java
@@ -1,0 +1,95 @@
+package com.github.ibm.mapepire.certstuff;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.UUID;
+
+import com.github.ibm.mapepire.Tracer;
+
+public class ServerCertPEM implements ServerCertInfo {
+
+    private final String m_storePass;
+    private KeyStore m_keystore = null;
+    private final String m_keyPass;
+    private final String m_alias;
+    private final File m_file;
+    private final File m_privateKeyFile;
+
+    public ServerCertPEM(final File _pemFile, final File _privKeyFile) throws FileNotFoundException {
+        if (!_pemFile.exists())
+            throw new FileNotFoundException(_pemFile.getAbsolutePath());
+        if (!_privKeyFile.exists())
+            throw new FileNotFoundException(_privKeyFile.getAbsolutePath());
+        m_file = _pemFile;
+        m_privateKeyFile = _privKeyFile;
+        m_storePass = UUID.randomUUID().toString().replace("-", "").substring(0, 9);
+        System.out.println("password is " + m_storePass);
+        m_keyPass = m_storePass;
+        m_alias = "mapepire";
+
+    }
+
+    public KeyStore getKeyStore() throws KeyStoreException, NoSuchAlgorithmException,
+            FileNotFoundException, IOException, CertificateException, InterruptedException {
+        if (null != m_keystore) {
+            return m_keystore;
+        }
+
+        File p12 = File.createTempFile("mppcert", ".p12");
+        String[] cmd = new String[] {
+                "/QOpenSys/usr/bin/openssl",
+                "pkcs12",
+                "-export",
+                "-out",
+                p12.getAbsolutePath(),
+                "-inkey",
+                m_privateKeyFile.getAbsolutePath(),
+                "-in", m_file.getAbsolutePath(), "-name", m_alias, "-password", "pass:" + m_storePass
+        };
+        String[] env = new String[] { "QIBM_USE_DESCRIPTOR_STDIO=Y" }; // no idea why this is needed, but without it,
+                                                                       // openssl fails with a -1 return code
+        Process p = Runtime.getRuntime().exec(cmd, env);
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+            String line = null;
+            while (null != (line = br.readLine())) {
+                Tracer.warn("stderr from openssl call: " + line);
+            }
+        }
+        p.waitFor();
+        if (p.exitValue() != 0 || !p12.isFile()) {
+            Tracer.warn("openssl failed with rc: " + p.exitValue());
+            throw new IOException("intermediate export failed");
+        }
+
+        try (FileInputStream fis = new FileInputStream(p12)) {
+            KeyStore ret = KeyStore.getInstance("PKCS12");
+            ret.load(fis, m_storePass.toCharArray());
+            Tracer.info("loaded temporary PKCS12 (generated from PEM)");
+            return m_keystore = ret;
+        }
+    }
+
+    public String getAlias() {
+        return m_alias;
+    }
+
+    public String getStorePass() {
+        return m_storePass;
+    }
+
+    public String getKeyPass() {
+        return m_keyPass;
+    }
+
+    public File getKeyStoreFile() {
+        return m_file;
+    }
+}

--- a/src/main/java/com/github/ibm/mapepire/certstuff/ServerCertPEM.java
+++ b/src/main/java/com/github/ibm/mapepire/certstuff/ServerCertPEM.java
@@ -31,7 +31,6 @@ public class ServerCertPEM implements ServerCertInfo {
         m_file = _pemFile;
         m_privateKeyFile = _privKeyFile;
         m_storePass = UUID.randomUUID().toString().replace("-", "").substring(0, 9);
-        System.out.println("password is " + m_storePass);
         m_keyPass = m_storePass;
         m_alias = "mapepire";
 


### PR DESCRIPTION
Summary of changes:
- Add three new command-line options to turn on tracing for daemon mode: `--traceOn`, `--traceDs`, `--traceErrors`
- Use a global file (`/QOpenSys/etc/mapepire/cert/server.jks`) for the user-defined server certificate, if manually configured by the admin
- Change the default password and label of the user-defined server certificate to "mapepire"
- Automatically use LetsEncrypt certificates if they've been generated on the current system