### PR TITLE
Deployment-time tweaks

### DIFF
--- a/scripts/mapepire-start.sh
+++ b/scripts/mapepire-start.sh
@@ -1,2 +1,2 @@
 #!/QOpenSys/usr/bin/sh
-exec /QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java -jar $(/QOpenSys/usr/bin/dirname $0)/../lib/mapepire/mapepire-server.jar
+exec /QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java -Xsoftmx1G -Xmx16g -Xms256M -jar $(/QOpenSys/usr/bin/dirname $0)/../lib/mapepire/mapepire-server.jar

--- a/service-commander-def.yaml
+++ b/service-commander-def.yaml
@@ -2,6 +2,7 @@ name: Mapepire Server
 dir: .
 start_cmd: ../../bin/mapepire
 check_alive: mapepire,8076
-batch_mode: 'false'
+batch_mode: 'true'
+sbmjob_opts: 'JOBQ(QUSRNOMAX) ALWMLTTHD(*YES)'
 environment_vars:
 - PATH=/QOpenSys/pkgs/bin:/QOpenSys/usr/bin:/usr/ccs/bin:/QOpenSys/usr/bin/X11:/usr/sbin:.:/usr/bin


### PR DESCRIPTION
1. Set GC options to allow for large heap usage (facilitates many concurrent users)
2. Modify the default `sc` definition to submit to batch. Advantages:
   - Stderr/Stdout goes to a spooled file, ironically easier to find than `sc`-managed log files (and `sc`-managed log files are often in the launching user profile's home directory)
   - Good template usage for batch jobs with `sc` (so, for instance if someone wants mapepire to be in its own subsystem, memory pool, or capping group, it's easy to see how to do so)