### PR TITLE
Fixing crash on bad request due to NullPointerException

### DIFF
--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -158,6 +158,7 @@ public class DataStreamProcessor implements Runnable {
             case "execute":
                 if (null == cont_id) {
                     dispatch(new BadReq(this, m_conn, reqObj, "Correlation ID not specified"));
+                    break;
                 }
                 final PrepareSql prevP = m_prepStmtMap.get(cont_id.getAsString());
                 if (null == prevP) {

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -127,14 +127,14 @@ public class DataStreamProcessor implements Runnable {
                 break;
             case "sqlmore": {
                 if (null == cont_id) {
-                    dispatch(new BadReq(null, m_conn, reqObj, "Correlation ID not specified"));
+                    dispatch(new BadReq(this, m_conn, reqObj, "Correlation ID not specified"));
                 }
                 BlockRetrievableRequest prev = m_queriesMap.get(cont_id.getAsString());
                 if (null == prev) {
                     prev = m_prepStmtMap.get(cont_id.getAsString());
                 }
                 if (null == prev) {
-                    dispatch(new BadReq(null, m_conn, reqObj, "invalid correlation ID"));
+                    dispatch(new BadReq(this, m_conn, reqObj, "invalid correlation ID"));
                     break;
                 }
                 dispatch(new RunSqlMore(this, reqObj, prev));
@@ -142,14 +142,14 @@ public class DataStreamProcessor implements Runnable {
             }
             case "sqlclose": {
                 if (null == cont_id) {
-                    dispatch(new BadReq(null, m_conn, reqObj, "Correlation ID not specified"));
+                    dispatch(new BadReq(this, m_conn, reqObj, "Correlation ID not specified"));
                 }
                 BlockRetrievableRequest prev = m_queriesMap.get(cont_id.getAsString());
                 if (null == prev) {
                     prev = m_prepStmtMap.get(cont_id.getAsString());
                 }
                 if (null == prev) {
-                    dispatch(new BadReq(null, m_conn, reqObj, "invalid correlation ID"));
+                    dispatch(new BadReq(this, m_conn, reqObj, "invalid correlation ID"));
                     break;
                 }
                 dispatch(new CloseSqlCursor(this, reqObj, prev));
@@ -157,11 +157,11 @@ public class DataStreamProcessor implements Runnable {
             }
             case "execute":
                 if (null == cont_id) {
-                    dispatch(new BadReq(null, m_conn, reqObj, "Correlation ID not specified"));
+                    dispatch(new BadReq(this, m_conn, reqObj, "Correlation ID not specified"));
                 }
                 final PrepareSql prevP = m_prepStmtMap.get(cont_id.getAsString());
                 if (null == prevP) {
-                    dispatch(new BadReq(null, m_conn, reqObj, "invalid correlation ID"));
+                    dispatch(new BadReq(this, m_conn, reqObj, "invalid correlation ID"));
                     break;
                 }
                 dispatch(new PreparedExecute(this, reqObj, prevP));


### PR DESCRIPTION
Sending a request where the type needs additional json-properties leads to a NullPointerException which crashes the application.

Example:
`{"id":"1","type":"execute"}`

> java.lang.RuntimeException: Bad request: Correlation ID not specified
	at com.github.ibm.mapepire.requests.BadReq.go(BadReq.java:22)
	at com.github.ibm.mapepire.ClientRequest.run(ClientRequest.java:85)
	at java.base/java.lang.Thread.run(Thread.java:840)
java.sql.SQLException: Not connected
	at com.github.ibm.mapepire.SystemConnection.getJdbcConnection(SystemConnection.java:141)
	at com.github.ibm.mapepire.DataStreamProcessor.end(DataStreamProcessor.java:209)
	at com.github.ibm.mapepire.ws.DbWebsocketClient.onWebSocketError(DbWebsocketClient.java:50)
	at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onError(JettyListenerEventDriver.java:169)
	at org.eclipse.jetty.websocket.common.WebSocketSession.callApplicationOnError(WebSocketSession.java:416)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.close(AbstractWebSocketConnection.java:209)
	at org.eclipse.jetty.websocket.common.WebSocketSession.close(WebSocketSession.java:130)
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.incomingFrame(AbstractEventDriver.java:173)
	at org.eclipse.jetty.websocket.common.WebSocketSession.incomingFrame(WebSocketSession.java:326)
	at org.eclipse.jetty.websocket.common.extensions.AbstractExtension.nextIncomingFrame(AbstractExtension.java:148)
	at org.eclipse.jetty.websocket.common.extensions.compress.PerMessageDeflateExtension.nextIncomingFrame(PerMessageDeflateExtension.java:111)
	at org.eclipse.jetty.websocket.common.extensions.compress.PerMessageDeflateExtension.incomingFrame(PerMessageDeflateExtension.java:71)
	at org.eclipse.jetty.websocket.common.extensions.ExtensionStack.incomingFrame(ExtensionStack.java:202)
	at org.eclipse.jetty.websocket.common.Parser.notifyFrame(Parser.java:225)
	at org.eclipse.jetty.websocket.common.Parser.parseSingleFrame(Parser.java:259)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:459)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:440)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.produce(EatWhatYouKill.java:137)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
	at java.base/java.lang.Thread.run(Thread.java:840)
java.sql.SQLException: Not connected
	at com.github.ibm.mapepire.SystemConnection.getJdbcConnection(SystemConnection.java:141)
	at com.github.ibm.mapepire.DataStreamProcessor.end(DataStreamProcessor.java:209)
	at com.github.ibm.mapepire.ws.DbWebsocketClient.onWebSocketClose(DbWebsocketClient.java:43)
	at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onClose(JettyListenerEventDriver.java:149)
	at org.eclipse.jetty.websocket.common.WebSocketSession.callApplicationOnClose(WebSocketSession.java:394)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.close(AbstractWebSocketConnection.java:225)
	at org.eclipse.jetty.websocket.common.WebSocketSession.close(WebSocketSession.java:130)
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.incomingFrame(AbstractEventDriver.java:173)
	at org.eclipse.jetty.websocket.common.WebSocketSession.incomingFrame(WebSocketSession.java:326)
	at org.eclipse.jetty.websocket.common.extensions.AbstractExtension.nextIncomingFrame(AbstractExtension.java:148)
	at org.eclipse.jetty.websocket.common.extensions.compress.PerMessageDeflateExtension.nextIncomingFrame(PerMessageDeflateExtension.java:111)
	at org.eclipse.jetty.websocket.common.extensions.compress.PerMessageDeflateExtension.incomingFrame(PerMessageDeflateExtension.java:71)
	at org.eclipse.jetty.websocket.common.extensions.ExtensionStack.incomingFrame(ExtensionStack.java:202)
	at org.eclipse.jetty.websocket.common.Parser.notifyFrame(Parser.java:225)
	at org.eclipse.jetty.websocket.common.Parser.parseSingleFrame(Parser.java:259)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:459)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:440)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.produce(EatWhatYouKill.java:137)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
	at java.base/java.lang.Thread.run(Thread.java:840)
java.lang.NullPointerException: Cannot invoke "com.github.ibm.mapepire.DataStreamProcessor.sendResponse(String)" because "this.m_io" is null
	at com.github.ibm.mapepire.ClientRequest.sendreply(ClientRequest.java:129)
	at com.github.ibm.mapepire.ClientRequest.run(ClientRequest.java:98)
	at java.base/java.lang.Thread.run(Thread.java:840)


I fixed it with passing the current instance instead of null to the BadReq-constructor like it was done with all the other ClientRequest-Types.

