### PR TITLE
removed soft-memory-limit

### DIFF
--- a/scripts/mapepire-start.sh
+++ b/scripts/mapepire-start.sh
@@ -1,2 +1,2 @@
 #!/QOpenSys/usr/bin/sh
-QIBM_JAVA_STDIO_CONVERT=N QIBM_PASE_DESCRIPTOR_STDIO=B QIBM_USE_DESCRIPTOR_STDIO=Y QIBM_MULTI_THREADED=Y exec /QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java -Xsoftmx1G -Xmx16g -Xms256M -jar $(/QOpenSys/usr/bin/dirname $0)/../lib/mapepire/mapepire-server.jar $*
+QIBM_JAVA_STDIO_CONVERT=N QIBM_PASE_DESCRIPTOR_STDIO=B QIBM_USE_DESCRIPTOR_STDIO=Y QIBM_MULTI_THREADED=Y exec /QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java -Xmx16g -Xms256M -jar $(/QOpenSys/usr/bin/dirname $0)/../lib/mapepire/mapepire-server.jar $*


### PR DESCRIPTION
Removed the [soft-memory-limit](https://www.ibm.com/docs/en/sdk-java-technology/8?topic=options-xsoftmx) of 1G.
Couldnt find a usage of the associated com.ibm.lang.management-api.
1G of heap could lead to a fast OutOfMemoryError-Exception and make the server unresponsive(#81 ).


