### PR TITLE
Free memory for gc

### DIFF
--- a/src/main/java/com/github/ibm/mapepire/ClientRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/ClientRequest.java
@@ -126,6 +126,7 @@ public abstract class ClientRequest implements Runnable {
     protected void sendreply() throws UnsupportedEncodingException, IOException {
         final Gson l = new GsonBuilder().serializeNulls().create();
         final String json = l.toJson(replyData);
+        replyData.clear();
         m_io.sendResponse(json);
     }
 }

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -1,38 +1,15 @@
 package com.github.ibm.mapepire;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
-import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.Map;
-
-import com.github.ibm.mapepire.requests.BadReq;
-import com.github.ibm.mapepire.requests.BlockRetrievableRequest;
-import com.github.ibm.mapepire.requests.CloseSqlCursor;
-import com.github.ibm.mapepire.requests.DoVe;
-import com.github.ibm.mapepire.requests.Exit;
-import com.github.ibm.mapepire.requests.GetDbJob;
-import com.github.ibm.mapepire.requests.GetTraceData;
-import com.github.ibm.mapepire.requests.GetVersion;
-import com.github.ibm.mapepire.requests.IncompleteReq;
-import com.github.ibm.mapepire.requests.Ping;
-import com.github.ibm.mapepire.requests.PrepareSql;
-import com.github.ibm.mapepire.requests.PreparedExecute;
-import com.github.ibm.mapepire.requests.Reconnect;
-import com.github.ibm.mapepire.requests.RunCL;
-import com.github.ibm.mapepire.requests.RunSql;
-import com.github.ibm.mapepire.requests.RunSqlMore;
-import com.github.ibm.mapepire.requests.SetConfig;
-import com.github.ibm.mapepire.requests.UnknownReq;
-import com.github.ibm.mapepire.requests.UnparsableReq;
+import com.github.ibm.mapepire.requests.*;
 import com.github.theprez.jcmdutils.StringUtils;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+
+import java.io.*;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class DataStreamProcessor implements Runnable {
 
@@ -153,6 +130,9 @@ public class DataStreamProcessor implements Runnable {
                     break;
                 }
                 dispatch(new CloseSqlCursor(this, reqObj, prev));
+
+                m_queriesMap.remove(cont_id.getAsString());
+                m_prepStmtMap.remove(cont_id.getAsString());
                 break;
             }
             case "execute":


### PR DESCRIPTION
Every ClientRequest-Object keeps its response data until disconnect. Clearing the reponseData-Map and removing RunSql- and PrepareSql-Object from queriesMpa/prepStmtMap at sqlclose enables the Garbage Collector to free heap and avoids a memoryLeak(which is the issue in #81).

I tested the memory usage with 10.000 queries:

Before my changes(ended with an OutOfMemory-Error):
![grafik](https://github.com/user-attachments/assets/862f12a8-9872-4db4-a5bb-fc9759805e81)

After my changes:
![grafik](https://github.com/user-attachments/assets/6d083c1b-a991-41bc-ade9-3c5ff7bfb773)
