### PR TITLE
Increase max WS message size to 50MB and make it configurable

### DIFF
--- a/src/main/java/com/github/ibm/mapepire/MapepireServer.java
+++ b/src/main/java/com/github/ibm/mapepire/MapepireServer.java
@@ -157,8 +157,14 @@ public class MapepireServer {
                 // Configure specific websocket behavior
                 NativeWebSocketServletContainerInitializer.configure(context,
                         (servletContext, nativeWebSocketConfiguration) -> {
-                            // Configure default max size
                             nativeWebSocketConfiguration.getPolicy().setMaxTextMessageBufferSize(65535);
+                            // Configure max message size
+                            int maxWsMessageSize = 50 * 1024 * 1024; // 50MB
+                            String maxWsMessageSizeStr = System.getenv("MAX_WS_MESSAGE_SIZE");
+                            if (StringUtils.isNonEmpty(maxWsMessageSizeStr)) {
+                                maxWsMessageSize = Integer.parseInt(maxWsMessageSizeStr);
+                            }
+                            nativeWebSocketConfiguration.getPolicy().setMaxTextMessageSize(maxWsMessageSize);
 
                             // Add websockets
                             nativeWebSocketConfiguration.addMapping("/db/*", new DbSocketCreator());


### PR DESCRIPTION
This PR is intended as a quick/bandage fix for issue #82 .

It increases the default max WebSocket message size from 65KB to 50MB. Also makes the max message size configurable via env. variable `MAX_WS_MESSAGE_SIZE`.

The message buffer size is left as-is, at 65KB.