### PR TITLE
Fix release workflow to include server version in zip

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -62,10 +62,10 @@ jobs:
         mv target/mapepire-server-${{ env.project_version }}-jar-with-dependencies.jar staging/opt/mapepire/lib/mapepire/mapepire-server.jar
         mv service-commander-def.yaml staging/opt/mapepire/lib/mapepire/mapepire.yaml
 
-    - name: Create distribution .zip
+    - name: Create distribution .zip and move JAR file
       run: |
         pushd staging/opt/mapepire
-        zip -r ../../../mapepire-server-dist.zip bin lib
+        zip -r ../../../mapepire-server-${{ env.project_version }}.zip bin lib
         mv lib/mapepire/mapepire-server.jar ../../../mapepire-server.jar
         popd
 
@@ -75,7 +75,7 @@ jobs:
         tag_name: v${{ env.project_version }}
         name: v${{ env.project_version }}
         files: |
-          mapepire-server-dist.zip
+          mapepire-server-${{ env.project_version }}.zip
           mapepire-server.jar
 
     - name: Install NPM Dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.theprez</groupId>
     <artifactId>mapepire-server</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <name>Mapepire (IBM i) Server Component</name>
     <description>Server-side support for Mapepire cloud-native database access layer.</description>
     <url>https://github.com/Mapepire-IBMi/mapepire-server/</url>


### PR DESCRIPTION
This is to resolve an issue in the Jenkins Build due to source caching. This prevents all versions from being cached to mapepire-server-dist.zip.