### PR TITLE
Fix loss of umlauts

### DIFF
--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -8,8 +8,6 @@ import org.eclipse.jetty.websocket.api.WebSocketException;
 
 import java.io.*;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 public class DbWebsocketClient extends WebSocketAdapter {
@@ -57,35 +55,30 @@ public class DbWebsocketClient extends WebSocketAdapter {
     InputStream in = new ByteArrayInputStream(new byte[0]);
 
     OutputStream outStream = new OutputStream() {
-      private final List<Byte> payload = new ArrayList<>();
+      private final ByteArrayOutputStream payload = new ByteArrayOutputStream();
 
       @Override
       public void write(int b) {
-        this.payload.add((byte)b);
+        this.payload.write((byte)b);
       }
 
       public byte[] getBytes() {
-        byte[] byteArray = new byte[this.payload.size()];
-        for (int i = 0; i < this.payload.size() ; i++) {
-          byteArray[i] = payload.get(i);
-        }
-        return byteArray;
+        return payload.toByteArray();
       }
 
       @Override
       public void flush() throws IOException {
         if (endpoint.getRemote() != null) {
-          if (!payload.isEmpty()) {
+          if (payload.size() != 0) {
             byte[] payloadByteArray = this.getBytes();
             try {
               endpoint.getRemote().sendBytes(ByteBuffer.wrap(payloadByteArray));
             } catch (WebSocketException e){
-
               System.out.println("Could not send message: " + new String(payloadByteArray) + e.getMessage());
             }
           }
         }
-        this.payload.clear();
+        this.payload.reset();
       }
     };
 


### PR DESCRIPTION
Problem:
Querying text data from a column with ccsid 273 and content like "Perücke", "weiß" and "grün" didnt  work properly, umlauts and other special charakters were lost.

Example table:
`CREATE TABLE german_text (
    id INTEGER NOT NULL,
    text VARCHAR(2000) CCSID 273 DEFAULT '',
    PRIMARY KEY(id)
);`

`INSERT INTO german_text(id,text) values(1, 'grün'), (2, 'weiß'), (3, 'Perücke');`

'weiß' -> 'weiￃﾟ'
'grün' -> 'grￃﾼn'
'Perücke' -> 'Perￃﾼcke'

Currently the Response-json-String gets correctly UTF-8 encoded(com.github.ibm.mapepire.DataStreamProcessor#sendResponse) but the resulting byte-array gets build together to a new String(OutputStream-Implementation in com.github.ibm.mapepire.ws.DbWebsocketClient#getDataStream ) which reverts this.

My fix uses the sendBytes() instead of the sendString(). No new String is requiered.

