### PR TITLE
Revert websocket message type to `text`

### DIFF
--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -70,10 +70,8 @@ public class DbWebsocketClient extends WebSocketAdapter {
       public synchronized void flush() throws IOException {
         if (endpoint.getRemote() != null) {
           if (payload.size() != 0) {
-            this.write('\n');
-            byte[] payloadByteArray = this.getBytes();
             try {
-              endpoint.getRemote().sendString(new String(payloadByteArray, "UTF-8"));
+              endpoint.getRemote().sendString(this.payload.toString("UTF-8")+"\n");
             } catch (WebSocketException e){
               System.out.println("Could not send message: " + new String(payloadByteArray) + e.getMessage());
             }

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -73,7 +73,7 @@ public class DbWebsocketClient extends WebSocketAdapter {
             try {
               endpoint.getRemote().sendString(this.payload.toString("UTF-8")+"\n");
             } catch (WebSocketException e){
-              System.out.println("Could not send message: " + new String(payloadByteArray) + e.getMessage());
+              System.out.println("Could not send message: " + message + ". Error: " + e.getMessage());
             }
           }
         }

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -74,7 +74,7 @@ public class DbWebsocketClient extends WebSocketAdapter {
             try {
               endpoint.getRemote().sendString(message);
             } catch (WebSocketException e){
-              System.out.println("Could not send message: " + message + ". Error: " + e.getMessage());
+              System.err.println("Could not send message due to error: " + e.getMessage());
             }
           }
         }

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -70,7 +70,7 @@ public class DbWebsocketClient extends WebSocketAdapter {
       public synchronized void flush() throws IOException {
         if (endpoint.getRemote() != null) {
           if (payload.size() != 0) {
-            String message = this.payload.toString("UTF-8");
+            String message = this.payload.toString("UTF-8") + "\n";
             try {
               endpoint.getRemote().sendString(message);
             } catch (WebSocketException e){

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -58,7 +58,7 @@ public class DbWebsocketClient extends WebSocketAdapter {
       private final ByteArrayOutputStream payload = new ByteArrayOutputStream();
 
       @Override
-      public void write(int b) {
+      public synchronized void write(int b) {
         this.payload.write((byte)b);
       }
 
@@ -67,13 +67,13 @@ public class DbWebsocketClient extends WebSocketAdapter {
       }
 
       @Override
-      public void flush() throws IOException {
+      public synchronized void flush() throws IOException {
         if (endpoint.getRemote() != null) {
           if (payload.size() != 0) {
             this.write('\n');
             byte[] payloadByteArray = this.getBytes();
             try {
-              endpoint.getRemote().sendBytes(ByteBuffer.wrap(payloadByteArray));
+              endpoint.getRemote().sendString(new String(payloadByteArray, "UTF-8"));
             } catch (WebSocketException e){
               System.out.println("Could not send message: " + new String(payloadByteArray) + e.getMessage());
             }

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -72,7 +72,7 @@ public class DbWebsocketClient extends WebSocketAdapter {
           if (payload.size() != 0) {
             String message = this.payload.toString("UTF-8");
             try {
-              endpoint.getRemote().sendString(this.payload.toString("UTF-8")+"\n");
+              endpoint.getRemote().sendString(message);
             } catch (WebSocketException e){
               System.out.println("Could not send message: " + message + ". Error: " + e.getMessage());
             }

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -70,6 +70,7 @@ public class DbWebsocketClient extends WebSocketAdapter {
       public synchronized void flush() throws IOException {
         if (endpoint.getRemote() != null) {
           if (payload.size() != 0) {
+            String message = this.payload.toString("UTF-8");
             try {
               endpoint.getRemote().sendString(this.payload.toString("UTF-8")+"\n");
             } catch (WebSocketException e){


### PR DESCRIPTION
Changes in #111 indirectly caused the websocket message type to switch from `binary` to `text`
(see https://noio-ws.readthedocs.io/en/latest/overview_of_websockets.html among others documenting websockets proto)

Since we are sending JSON, `text` seems most appropriate, and we're less likely to break existing clients