### PR TITLE
Blob binary transmission

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
-        <jetty.version>9.4.54.v20240208</jetty.version>
+        <jetty.version>9.4.57.v20241219</jetty.version>
     </properties>
     <build>
         <defaultGoal>install</defaultGoal>
@@ -221,6 +221,7 @@
             <artifactId>websocket-server</artifactId>
             <version>${jetty.version}</version>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -160,8 +160,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>9</source>
+                    <target>9</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -226,6 +226,24 @@
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-server</artifactId>
             <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version> <!-- use the latest -->
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.2</version> <!-- use the latest -->
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <dependency>
             <groupId>net.sf.jt400</groupId>
             <artifactId>jt400</artifactId>
-            <version>11.2</version>
+            <version>21.0.5</version>
             <!-- comment the <scope> tag for local development -->
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
         <jetty.version>9.4.57.v20241219</jetty.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,14 @@
                         </descriptorRefs>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <debug>true</debug>
+                        <debuglevel>lines,vars,source</debuglevel>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/src/main/java/com/github/ibm/mapepire/BlobRequestData.java
+++ b/src/main/java/com/github/ibm/mapepire/BlobRequestData.java
@@ -1,0 +1,26 @@
+package com.github.ibm.mapepire;
+
+public class BlobRequestData {
+
+    private int replacementIndex;
+    private int length;
+    private int offset;
+
+    public BlobRequestData(int replacementIndex, int length, int offset){
+        this.replacementIndex = replacementIndex;
+        this.length = length;
+        this.offset = offset;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public int getReplacementIndex() {
+        return replacementIndex;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+}

--- a/src/main/java/com/github/ibm/mapepire/BlobResponseData.java
+++ b/src/main/java/com/github/ibm/mapepire/BlobResponseData.java
@@ -6,11 +6,13 @@ public class BlobResponseData {
     final InputStream is;
     final String columnName;
     final int rowId;
+    final int length;
 
-    public BlobResponseData(InputStream is, String columnName, int rowId){
+    public BlobResponseData(InputStream is, String columnName, int rowId, int length){
         this.is = is;
         this.columnName = columnName;
         this.rowId = rowId;
+        this.length = length;
     }
 
     public InputStream getIs() {
@@ -23,5 +25,9 @@ public class BlobResponseData {
 
     public int getRowId(){
         return rowId;
+    }
+
+    public int getLength(){
+        return length;
     }
 }

--- a/src/main/java/com/github/ibm/mapepire/BlobResponseData.java
+++ b/src/main/java/com/github/ibm/mapepire/BlobResponseData.java
@@ -1,0 +1,27 @@
+package com.github.ibm.mapepire;
+
+import java.io.InputStream;
+
+public class BlobResponseData {
+    final InputStream is;
+    final String columnName;
+    final int rowId;
+
+    public BlobResponseData(InputStream is, String columnName, int rowId){
+        this.is = is;
+        this.columnName = columnName;
+        this.rowId = rowId;
+    }
+
+    public InputStream getIs() {
+        return is;
+    }
+
+    public String getColumnName(){
+        return columnName;
+    }
+
+    public int getRowId(){
+        return rowId;
+    }
+}

--- a/src/main/java/com/github/ibm/mapepire/BlobResponseData.java
+++ b/src/main/java/com/github/ibm/mapepire/BlobResponseData.java
@@ -1,22 +1,23 @@
 package com.github.ibm.mapepire;
 
 import java.io.InputStream;
+import java.sql.Blob;
 
 public class BlobResponseData {
-    final InputStream is;
+    final Blob blob;
     final String columnName;
     final int rowId;
     final int length;
 
-    public BlobResponseData(InputStream is, String columnName, int rowId, int length){
-        this.is = is;
+    public BlobResponseData(Blob is, String columnName, int rowId, int length){
+        this.blob = is;
         this.columnName = columnName;
         this.rowId = rowId;
         this.length = length;
     }
 
-    public InputStream getIs() {
-        return is;
+    public Blob getBlob() {
+        return blob;
     }
 
     public String getColumnName(){

--- a/src/main/java/com/github/ibm/mapepire/ClientRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/ClientRequest.java
@@ -122,7 +122,7 @@ public abstract class ClientRequest implements Runnable {
         return "Internal Error: " + _e.getClass().getSimpleName();
     }
 
-    protected void sendreply() throws UnsupportedEncodingException, IOException {
+    protected void sendreply() throws IOException {
         final Gson l = new GsonBuilder().serializeNulls().create();
         final String json = l.toJson(replyData);
         replyData.clear();

--- a/src/main/java/com/github/ibm/mapepire/ClientRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/ClientRequest.java
@@ -16,7 +16,7 @@ import com.google.gson.JsonObject;
 public abstract class ClientRequest implements Runnable {
     private final SystemConnection m_conn;
     private final String m_id;
-    private final DataStreamProcessor m_io;
+    protected final DataStreamProcessor m_io;
     private final JsonObject m_reqObj;
     private final Map<String, Object> replyData = new LinkedHashMap<String, Object>();
 
@@ -26,10 +26,6 @@ public abstract class ClientRequest implements Runnable {
         m_id = _reqObj.get("id").getAsString();
         m_conn = _conn;
         addReplyData("id", m_id);
-    }
-
-    public SystemConnection getConnection() {
-        return m_conn;
     }
 
     protected void addReplyData(final String _key, final Object _val) {

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonParser;
 
 import java.io.*;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -274,8 +275,7 @@ public class DataStreamProcessor implements Runnable {
     public void sendResponse(final InputStream is, final String id) throws UnsupportedEncodingException, IOException {
         synchronized (s_replyWriterLock) {
             byte[] buffer = new byte[8192];
-            short idValue = Short.parseShort(id);
-            byte[] idBytes = ByteBuffer.allocate(2).putShort(idValue).array();
+            byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
             System.arraycopy(idBytes, 0, buffer, 0, idBytes.length);
 
             int bytesRead;

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -94,7 +94,7 @@ public class DataStreamProcessor implements Runnable {
 //        byte[] blob = Arrays.copyOfRange(payload, 6, payload.length);
         int blobOffset = 6;
         try {
-            RunBlob runBlob = new RunBlob(this, payload, offset, len, prev);
+            RunBlob runBlob = new RunBlob(this, payload, blobOffset, len, prev);
         } catch (Exception e) {
             System.out.println("Caught exception " + e);
         }

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -286,7 +286,7 @@ public class DataStreamProcessor implements Runnable {
     public void sendResponse(final String id, final BlobResponseData blobResponseData) throws IOException, SQLException {
         synchronized (s_replyWriterLock) {
             int curOffset = 0;
-            byte[] buffer = new byte[8 * 1024 * 1024];
+            byte[] buffer = new byte[4 * 1024 * 1024];
             byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
 
 //                buffer = new byte[8192];

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -318,9 +318,13 @@ public class DataStreamProcessor implements Runnable {
                 curOffset += columnNameBytes.length;
 
                 // Copy blob length
-                buffer[curOffset] = (byte) is.available();
-                curOffset += 1;
-
+                ByteBuffer blobLength = ByteBuffer.allocate(4);
+                blobLength.putInt(is.available()); // default is big-endian
+                byte[] bytes = blobLength.array();
+                for (int j = 0; j < 4; j++){
+                    buffer[curOffset] = bytes[j];
+                    curOffset += 1;
+                }
 
                 int bytesRead = is.read(buffer, curOffset, buffer.length - curOffset);
                 curOffset += bytesRead;

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -323,7 +323,7 @@ public class DataStreamProcessor implements Runnable {
 
                 // Copy blob length
                 ByteBuffer blobLength = ByteBuffer.allocate(4);
-                blobLength.putInt(is.available()); // default is big-endian
+                blobLength.putInt(blobResponseData.getLength()); // default is big-endian
                 byte[] bytes = blobLength.array();
                 for (int j = 0; j < 4; j++){
                     buffer[curOffset] = bytes[j];
@@ -332,13 +332,15 @@ public class DataStreamProcessor implements Runnable {
 
                 int bytesRead = is.read(buffer, curOffset, buffer.length - curOffset);
                 curOffset += bytesRead;
+                int totalBytesRead = bytesRead;
                 if (bytesRead != -1) {
-                    boolean isFinal = i == blobResponseDataArr.size() - 1 && is.available() == 0;
+                    boolean isFinal = i == blobResponseDataArr.size() - 1 && totalBytesRead == blobResponseData.getLength();
                     sendByteBuffer(buffer, curOffset, isFinal);
                 }
 
                 while ((bytesRead = is.read(buffer)) != -1) {
-                    boolean isFinal = i == blobResponseDataArr.size() - 1 && is.available() == 0;
+                    totalBytesRead += bytesRead;
+                    boolean isFinal = i == blobResponseDataArr.size() - 1 && totalBytesRead == blobResponseData.getLength();
                     sendByteBuffer(buffer, bytesRead, isFinal);
                 }
             }

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -1,6 +1,7 @@
 package com.github.ibm.mapepire;
 
 import com.github.ibm.mapepire.requests.*;
+import com.github.ibm.mapepire.ws.AsyncSender;
 import com.github.ibm.mapepire.ws.BinarySender;
 import com.github.ibm.mapepire.ws.DbWebsocketClient;
 import com.github.theprez.jcmdutils.StringUtils;
@@ -25,10 +26,10 @@ public class DataStreamProcessor implements Runnable {
     private final Map<String, RunSql> m_queriesMap = new HashMap<String, RunSql>();
     private final Map<String, PrepareSql> m_prepStmtMap = new HashMap<String, PrepareSql>();
     private final boolean m_isTestMode;
-    private final BinarySender m_binarySender;
+    private final AsyncSender m_binarySender;
 //    private final DbWebsocketClient.BinarySender m_binarySender;
 
-    public DataStreamProcessor(final InputStream _in, final PrintStream _outText, final BinarySender binarySender, final SystemConnection _conn,
+    public DataStreamProcessor(final InputStream _in, final PrintStream _outText, final AsyncSender binarySender, final SystemConnection _conn,
                                boolean _isTestMode)
             throws UnsupportedEncodingException {
         m_in = new BufferedReader(new InputStreamReader(_in, "UTF-8"));

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -305,9 +305,13 @@ public class DataStreamProcessor implements Runnable {
                 }
 
                 // Copy rowId
-                buffer[curOffset] = (byte) rowId;
-                curOffset += 1;
-
+                ByteBuffer rowIdBuffer = ByteBuffer.allocate(4);
+                rowIdBuffer.putInt(rowId); // default is big-endian
+                byte[] rowIdBytes = rowIdBuffer.array();
+                for (int j = 0; j < 4; j++){
+                    buffer[curOffset] = rowIdBytes[j];
+                    curOffset += 1;
+                }
 
                 // Copy column length
                 buffer[curOffset] = (byte) columnName.length();

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonParser;
 
 import java.io.*;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -64,6 +65,41 @@ public class DataStreamProcessor implements Runnable {
             Tracer.err(e);
             System.exit(6);
         }
+    }
+
+    private int bytesToInt(byte[] bytes, int offset, int length) {
+        int x = 0;
+        for (int i = offset; i < offset + length; i++){
+            byte b = bytes[i];
+            x = x << 8 | b & 0xFF;
+        }
+        return x;
+    }
+
+
+
+    public void run(byte[] binary) {
+        int cont_id = bytesToInt(binary, 0, 2);
+        int length = bytesToInt(binary, 2, 4);
+
+        if (binary.length - 6 != length){
+            throw new RuntimeException("Invalid binary data recieved.");
+        }
+
+
+        PrepareSql prev = m_prepStmtMap.get(cont_id);
+        if (null == prev) {
+            dispatch(new BadReq(this, m_conn, null, "invalid correlation ID"));
+            return;
+        }
+        byte[] blob = Arrays.copyOfRange(binary, 6, binary.length);
+    try {
+        RunBlob runBlob = new RunBlob(this, blob, prev);
+
+    } catch (Exception e){
+
+    }
+
     }
 
     public void run(String requestString) {

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -87,7 +87,7 @@ public class DataStreamProcessor implements Runnable {
         }
 
 
-        PrepareSql prev = m_prepStmtMap.get(cont_id);
+        PrepareSql prev = m_prepStmtMap.get(String.valueOf(cont_id));
         if (null == prev) {
             dispatch(new BadReq(this, m_conn, null, "invalid correlation ID"));
             return;
@@ -95,9 +95,8 @@ public class DataStreamProcessor implements Runnable {
         byte[] blob = Arrays.copyOfRange(binary, 6, binary.length);
     try {
         RunBlob runBlob = new RunBlob(this, blob, prev);
-
     } catch (Exception e){
-
+        System.out.println("Caught exception " + e);
     }
 
     }

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -275,7 +275,7 @@ public class DataStreamProcessor implements Runnable {
 //        }
 //    }
 
-    public void sendResponse(final String id, final List<BlobResponseData> blobResponseDataArr) throws IOException {
+    public void sendResponse(final String id, final List<BlobResponseData> blobResponseDataArr) throws IOException, SQLException {
         synchronized (s_replyWriterLock) {
             int curOffset = 0;
             byte[] buffer = new byte[8192];
@@ -286,7 +286,7 @@ public class DataStreamProcessor implements Runnable {
                 curOffset = 0;
                 BlobResponseData blobResponseData = blobResponseDataArr.get(i);
                 String columnName = blobResponseData.getColumnName();
-                InputStream is = blobResponseData.getIs();
+                InputStream is = blobResponseData.getBlob().getBinaryStream();
                 int rowId = blobResponseData.getRowId();
 
                 byte[] columnNameBytes = columnName.getBytes(StandardCharsets.UTF_8);

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -274,7 +274,7 @@ public class DataStreamProcessor implements Runnable {
 //        }
 //    }
 
-    public void sendResponse(final InputStream is, final String id, final String column) throws IOException {
+    public void sendResponse(final InputStream is, final String id, final String column, final int rowId) throws IOException {
         synchronized (s_replyWriterLock) {
             int curOffset = 0;
             byte[] buffer = new byte[8192];
@@ -292,6 +292,11 @@ public class DataStreamProcessor implements Runnable {
             System.arraycopy(idBytes, 0, buffer, curOffset, idBytes.length);
             curOffset += idBytes.length;
 
+            // Copy rowId
+            buffer[curOffset] = (byte) rowId;
+            curOffset += 1;
+
+
             // Copy column length
             buffer[curOffset] = (byte) column.length();
             curOffset += 1;
@@ -299,6 +304,10 @@ public class DataStreamProcessor implements Runnable {
             // copy column name
             System.arraycopy(columnNameBytes, 0, buffer, curOffset, columnNameBytes.length);
             curOffset += columnNameBytes.length;
+
+            // Copy blob length
+            buffer[curOffset] = (byte) is.available();
+            curOffset += 1;
 
 
             int bytesRead = is.read(buffer, curOffset, buffer.length - curOffset);

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -94,7 +94,7 @@ public class DataStreamProcessor implements Runnable {
 //        byte[] blob = Arrays.copyOfRange(payload, 6, payload.length);
         int blobOffset = 6;
         try {
-            RunBlob runBlob = new RunBlob(this, payload, blobOffset, len, prev);
+            RunBlob runBlob = new RunBlob(this, payload, blobOffset, length, prev);
         } catch (Exception e) {
             System.out.println("Caught exception " + e);
         }

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -278,10 +278,10 @@ public class DataStreamProcessor implements Runnable {
     public void sendResponse(final String id, final BlobResponseData blobResponseData) throws IOException, SQLException {
         synchronized (s_replyWriterLock) {
             int curOffset = 0;
-            byte[] buffer = new byte[8192];
+            byte[] buffer = new byte[4 * 1024 * 1024];
             byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
 
-                buffer = new byte[8192];
+//                buffer = new byte[8192];
                 curOffset = 0;
                 String columnName = blobResponseData.getColumnName();
                 InputStream is = blobResponseData.getBlob().getBinaryStream();

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -14,6 +14,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
 
 public class DataStreamProcessor implements Runnable {
 
@@ -352,7 +353,7 @@ public class DataStreamProcessor implements Runnable {
         }
     }
 
-    private void sendByteBuffer(byte[] buffer, int bytesRead, boolean isFinal) throws IOException {
+    private void sendByteBuffer(byte[] buffer, int bytesRead, boolean isFinal) {
         // Wrap only the bytes actually read
         ByteBuffer byteBuffer = ByteBuffer.wrap(buffer, 0, bytesRead);
 

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -286,7 +286,7 @@ public class DataStreamProcessor implements Runnable {
     public void sendResponse(final String id, final BlobResponseData blobResponseData) throws IOException, SQLException {
         synchronized (s_replyWriterLock) {
             int curOffset = 0;
-            byte[] buffer = new byte[4 * 1024 * 1024];
+            byte[] buffer = new byte[8 * 1024 * 1024];
             byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
 
 //                buffer = new byte[8192];

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -24,7 +24,7 @@ public class DataStreamProcessor implements Runnable {
     private final boolean m_isTestMode;
 
     public DataStreamProcessor(final InputStream _in, final PrintStream _out, final SystemConnection _conn,
-            boolean _isTestMode)
+                               boolean _isTestMode)
             throws UnsupportedEncodingException {
         m_in = new BufferedReader(new InputStreamReader(_in, "UTF-8"));
         m_out = _out;
@@ -69,7 +69,7 @@ public class DataStreamProcessor implements Runnable {
 
     private int bytesToInt(byte[] bytes, int offset, int length) {
         int x = 0;
-        for (int i = offset; i < offset + length; i++){
+        for (int i = offset; i < offset + length; i++) {
             byte b = bytes[i];
             x = x << 8 | b & 0xFF;
         }
@@ -77,12 +77,11 @@ public class DataStreamProcessor implements Runnable {
     }
 
 
+    public void run(byte[] payload, int offset, int len) {
+        int cont_id = bytesToInt(payload, offset, 2);
+        int length = bytesToInt(payload, offset + 2, 4);
 
-    public void run(byte[] binary) {
-        int cont_id = bytesToInt(binary, 0, 2);
-        int length = bytesToInt(binary, 2, 4);
-
-        if (binary.length - 6 != length){
+        if (payload.length - 6 != length) {
             throw new RuntimeException("Invalid binary data recieved.");
         }
 
@@ -92,14 +91,38 @@ public class DataStreamProcessor implements Runnable {
             dispatch(new BadReq(this, m_conn, null, "invalid correlation ID"));
             return;
         }
-        byte[] blob = Arrays.copyOfRange(binary, 6, binary.length);
-    try {
-        RunBlob runBlob = new RunBlob(this, blob, prev);
-    } catch (Exception e){
-        System.out.println("Caught exception " + e);
+//        byte[] blob = Arrays.copyOfRange(payload, 6, payload.length);
+        int blobOffset = 6;
+        try {
+            RunBlob runBlob = new RunBlob(this, payload, offset, len, prev);
+        } catch (Exception e) {
+            System.out.println("Caught exception " + e);
+        }
     }
 
-    }
+
+//    public void run(byte[] binary) {
+//        int cont_id = bytesToInt(binary, 0, 2);
+//        int length = bytesToInt(binary, 2, 4);
+//
+//        if (binary.length - 6 != length) {
+//            throw new RuntimeException("Invalid binary data recieved.");
+//        }
+//
+//
+//        PrepareSql prev = m_prepStmtMap.get(String.valueOf(cont_id));
+//        if (null == prev) {
+//            dispatch(new BadReq(this, m_conn, null, "invalid correlation ID"));
+//            return;
+//        }
+//        byte[] blob = Arrays.copyOfRange(binary, 6, binary.length);
+//        try {
+//            RunBlob runBlob = new RunBlob(this, blob, prev);
+//        } catch (Exception e) {
+//            System.out.println("Caught exception " + e);
+//        }
+//
+//    }
 
     public void run(String requestString) {
         final JsonElement reqElement;

--- a/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
+++ b/src/main/java/com/github/ibm/mapepire/DataStreamProcessor.java
@@ -135,6 +135,12 @@ public class DataStreamProcessor implements Runnable {
                 m_prepStmtMap.remove(cont_id.getAsString());
                 break;
             }
+//            case "blob": {
+//                final RunBlob blob = new RunBlob(this, m_conn, reqObj);
+//                m_queriesMap.put(runSqlReq.getId(), runSqlReq);
+//                dispatch(runSqlReq);
+//                break;
+//            }
             case "execute":
                 if (null == cont_id) {
                     dispatch(new BadReq(this, m_conn, reqObj, "Correlation ID not specified"));

--- a/src/main/java/com/github/ibm/mapepire/MapepireServer.java
+++ b/src/main/java/com/github/ibm/mapepire/MapepireServer.java
@@ -10,6 +10,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import com.github.ibm.mapepire.ws.DbWebsocketClient;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.server.Server;
@@ -67,9 +68,10 @@ public class MapepireServer {
                 if (testMode) {
                     System.setIn(new FileInputStream(testFile));
                 }
-                final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, conn, testMode);
+//                DbWebsocketClient.BinarySender binarySender = (data, isLast) -> remote.sendPartialBytes(data, isLast);
+//                final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, conn, testMode);
 
-                io.run();
+//                io.run();
             } else {
                 s_isSingleMode = false;
 

--- a/src/main/java/com/github/ibm/mapepire/MapepireServer.java
+++ b/src/main/java/com/github/ibm/mapepire/MapepireServer.java
@@ -39,6 +39,10 @@ public class MapepireServer {
         return s_isSingleMode;
     }
 
+    private static int getNumBytesInMb(int num){
+        return num * 1024 * 1024;
+    }
+
     public static void main(final String[] _args) {
 
         final LinkedList<String> args = new LinkedList<String>();
@@ -170,12 +174,15 @@ public class MapepireServer {
                         (servletContext, nativeWebSocketConfiguration) -> {
                             nativeWebSocketConfiguration.getPolicy().setMaxTextMessageBufferSize(65535);
                             // Configure max message size
-                            int maxWsMessageSize = 200 * 1024 * 1024; // 50MB
+                            int maxWsMessageSize = getNumBytesInMb(200);
+                            int maxBinaryMessageSize = getNumBytesInMb(200);
                             String maxWsMessageSizeStr = System.getenv("MAX_WS_MESSAGE_SIZE");
                             if (StringUtils.isNonEmpty(maxWsMessageSizeStr)) {
                                 maxWsMessageSize = Integer.parseInt(maxWsMessageSizeStr);
                             }
                             nativeWebSocketConfiguration.getPolicy().setMaxTextMessageSize(maxWsMessageSize);
+                            nativeWebSocketConfiguration.getPolicy().setMaxBinaryMessageSize(maxBinaryMessageSize);
+
 
                             // Add websockets
                             nativeWebSocketConfiguration.addMapping("/db/*", new DbSocketCreator());

--- a/src/main/java/com/github/ibm/mapepire/MapepireServer.java
+++ b/src/main/java/com/github/ibm/mapepire/MapepireServer.java
@@ -170,7 +170,7 @@ public class MapepireServer {
                         (servletContext, nativeWebSocketConfiguration) -> {
                             nativeWebSocketConfiguration.getPolicy().setMaxTextMessageBufferSize(65535);
                             // Configure max message size
-                            int maxWsMessageSize = 50 * 1024 * 1024; // 50MB
+                            int maxWsMessageSize = 200 * 1024 * 1024; // 50MB
                             String maxWsMessageSizeStr = System.getenv("MAX_WS_MESSAGE_SIZE");
                             if (StringUtils.isNonEmpty(maxWsMessageSizeStr)) {
                                 maxWsMessageSize = Integer.parseInt(maxWsMessageSizeStr);

--- a/src/main/java/com/github/ibm/mapepire/MapepireServer.java
+++ b/src/main/java/com/github/ibm/mapepire/MapepireServer.java
@@ -68,9 +68,7 @@ public class MapepireServer {
                 if (testMode) {
                     System.setIn(new FileInputStream(testFile));
                 }
-//                DbWebsocketClient.BinarySender binarySender = (data, isLast) -> remote.sendPartialBytes(data, isLast);
 //                final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, conn, testMode);
-
 //                io.run();
             } else {
                 s_isSingleMode = false;

--- a/src/main/java/com/github/ibm/mapepire/Version.java
+++ b/src/main/java/com/github/ibm/mapepire/Version.java
@@ -1,5 +1,5 @@
 package com.github.ibm.mapepire;
 public class Version {
-      static public final String s_compileDateTime = "2025-08-12 20:50:37 (GMT)";
+      static public final String s_compileDateTime = "2025-08-25 16:06:39 (GMT)";
       static public final String s_version = "2.3.3";
 }

--- a/src/main/java/com/github/ibm/mapepire/Version.java
+++ b/src/main/java/com/github/ibm/mapepire/Version.java
@@ -1,5 +1,5 @@
 package com.github.ibm.mapepire;
 public class Version {
-      static public final String s_compileDateTime = "2024-08-08 00:36:20 (GMT)";
-      static public final String s_version = "2.0.0-rc1";
+      static public final String s_compileDateTime = "2025-08-12 20:50:37 (GMT)";
+      static public final String s_version = "2.3.3";
 }

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -144,12 +144,8 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                 } else if (cellData instanceof Blob){
                     blobsNeeded++;
                     int blobLength = (int) ((Blob) cellData).length();
-//                    InputStream is = _rs.getBinaryStream(col);
                     BlobResponseData blobResponseData = new BlobResponseData((Blob)cellData, column, rowId, blobLength);
-
                     m_io.sendResponse(this.getId(), blobResponseData);
-//                    blobResponseDataArray.add(blobResponseData);
-//                    cellDataForResponse = _rs.getBytes(col);
                 }
                  else {
                     cellDataForResponse = _rs.getString(col);
@@ -163,7 +159,6 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
             ret.add(_isTerseDataFormat ? terseRowData : mapRowData);
             addReplyData("blobsNeeded", blobsNeeded);
         }
-//        m_io.sendResponse(this.getId(), blobResponseDataArray);
         return ret;
     }
 

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -139,8 +139,9 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                 } else if (cellData instanceof Number || cellData instanceof Boolean) {
                     cellDataForResponse = cellData;
                 } else if (cellData instanceof Blob){
+                    String id = this.getId();
                     InputStream is = _rs.getBinaryStream(col);
-                    m_io.sendResponse(is);
+                    m_io.sendResponse(is, id);
 
 //                    cellDataForResponse = _rs.getBytes(col);
                 }

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -1,5 +1,6 @@
 package com.github.ibm.mapepire.requests;
 
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.*;
 import java.util.LinkedHashMap;
@@ -11,6 +12,7 @@ import com.github.ibm.mapepire.ClientRequest;
 import com.github.ibm.mapepire.DataStreamProcessor;
 import com.github.ibm.mapepire.SystemConnection;
 import com.google.gson.JsonObject;
+import com.ibm.as400.access.AS400JDBCBlobLocator;
 import com.ibm.as400.access.AS400JDBCParameterMetaData;
 
 public abstract class BlockRetrievableRequest extends ClientRequest {
@@ -133,6 +135,8 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                     }
                 } else if (cellData instanceof Number || cellData instanceof Boolean) {
                     cellDataForResponse = cellData;
+                } else if (cellData instanceof AS400JDBCBlobLocator){
+                    cellDataForResponse = _rs.getBytes(col);
                 }
                  else {
                     cellDataForResponse = _rs.getString(col);

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -143,8 +143,8 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                 } else if (cellData instanceof Blob){
                     String id = this.getId();
                     int blobLength = (int) ((Blob) cellData).length();
-                    InputStream is = _rs.getBinaryStream(col);
-                    BlobResponseData blobResponseData = new BlobResponseData(is, column, rowId, blobLength);
+//                    InputStream is = _rs.getBinaryStream(col);
+                    BlobResponseData blobResponseData = new BlobResponseData((Blob)cellData, column, rowId, blobLength);
                     blobResponseDataArray.add(blobResponseData);
 //                    cellDataForResponse = _rs.getBytes(col);
                 }

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -1,5 +1,6 @@
 package com.github.ibm.mapepire.requests;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.*;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -132,6 +133,9 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                     }
                 } else if (cellData instanceof Number || cellData instanceof Boolean) {
                     cellDataForResponse = cellData;
+                }
+                else if (cellData instanceof Blob){
+                        cellDataForResponse = new String((byte[]) cellData, StandardCharsets.UTF_8);
                 } else {
                     cellDataForResponse = _rs.getString(col);
                 }

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -142,8 +142,9 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                     cellDataForResponse = cellData;
                 } else if (cellData instanceof Blob){
                     String id = this.getId();
+                    int blobLength = (int) ((Blob) cellData).length();
                     InputStream is = _rs.getBinaryStream(col);
-                    BlobResponseData blobResponseData = new BlobResponseData(is, column, rowId);
+                    BlobResponseData blobResponseData = new BlobResponseData(is, column, rowId, blobLength);
                     blobResponseDataArray.add(blobResponseData);
 //                    cellDataForResponse = _rs.getBytes(col);
                 }

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -124,6 +124,8 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
             final LinkedHashMap<String, Object> mapRowData = new LinkedHashMap<String, Object>();
             final LinkedList<Object> terseRowData = new LinkedList<Object>();
             final int numCols = _rs.getMetaData().getColumnCount();
+            int rowId = i;
+            mapRowData.put("rowId", rowId);
             for (int col = 1; col <= numCols; ++col) {
                 String column = _rs.getMetaData().getColumnName(col);
                 Object cellData = _rs.getObject(col);
@@ -141,7 +143,7 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                 } else if (cellData instanceof Blob){
                     String id = this.getId();
                     InputStream is = _rs.getBinaryStream(col);
-                    m_io.sendResponse(is, id, column);
+                    m_io.sendResponse(is, id, column, rowId);
 
 //                    cellDataForResponse = _rs.getBytes(col);
                 }

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -4,17 +4,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.*;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
+import com.github.ibm.mapepire.BlobResponseData;
 import com.github.ibm.mapepire.ClientRequest;
 import com.github.ibm.mapepire.DataStreamProcessor;
 import com.github.ibm.mapepire.SystemConnection;
 import com.google.gson.JsonObject;
 import com.ibm.as400.access.AS400JDBCBlobLocator;
 import com.ibm.as400.access.AS400JDBCParameterMetaData;
+import com.github.ibm.mapepire.BlobResponseData;
 
 public abstract class BlockRetrievableRequest extends ClientRequest {
 
@@ -110,6 +109,7 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
         if (_rs.isClosed()) {
             return ret.setDone(true);
         }
+        final List<BlobResponseData> blobResponseDataArray = new ArrayList<>();
         for (int i = 0; i < _numRows; ++i) {
             if (!_rs.next()) {
                 ret.setDone(true);
@@ -143,8 +143,8 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                 } else if (cellData instanceof Blob){
                     String id = this.getId();
                     InputStream is = _rs.getBinaryStream(col);
-                    m_io.sendResponse(is, id, column, rowId);
-
+                    BlobResponseData blobResponseData = new BlobResponseData(is, column, rowId);
+                    blobResponseDataArray.add(blobResponseData);
 //                    cellDataForResponse = _rs.getBytes(col);
                 }
                  else {
@@ -158,6 +158,7 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
             }
             ret.add(_isTerseDataFormat ? terseRowData : mapRowData);
         }
+        m_io.sendResponse(this.getId(), blobResponseDataArray);
         return ret;
     }
 

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -160,9 +160,7 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                 }
             }
             ret.add(_isTerseDataFormat ? terseRowData : mapRowData);
-            Map<String, Integer> blobsNeededMap = new HashMap();
-            blobsNeededMap.put("blobsNeeded", blobsNeeded);
-            ret.add(blobsNeededMap);
+            addReplyData("blobsNeeded", blobsNeeded);
         }
 //        m_io.sendResponse(this.getId(), blobResponseDataArray);
         return ret;

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -146,7 +146,14 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                     int blobLength = (int) ((Blob) cellData).length();
 //                    InputStream is = _rs.getBinaryStream(col);
                     BlobResponseData blobResponseData = new BlobResponseData((Blob)cellData, column, rowId, blobLength);
-                    m_io.sendResponse(this.getId(), blobResponseData);
+                    new Thread(() -> {
+                        try {
+                            m_io.sendResponse(this.getId(), blobResponseData);
+                        } catch (Exception e) {
+                            e.printStackTrace(); // or log it properly
+                        }
+                    }).start();
+//                    m_io.sendResponse(this.getId(), blobResponseData);
 //                    blobResponseDataArray.add(blobResponseData);
 //                    cellDataForResponse = _rs.getBytes(col);
                 }

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -146,14 +146,8 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                     int blobLength = (int) ((Blob) cellData).length();
 //                    InputStream is = _rs.getBinaryStream(col);
                     BlobResponseData blobResponseData = new BlobResponseData((Blob)cellData, column, rowId, blobLength);
-                    new Thread(() -> {
-                        try {
-                            m_io.sendResponse(this.getId(), blobResponseData);
-                        } catch (Exception e) {
-                            e.printStackTrace(); // or log it properly
-                        }
-                    }).start();
-//                    m_io.sendResponse(this.getId(), blobResponseData);
+
+                    m_io.sendResponse(this.getId(), blobResponseData);
 //                    blobResponseDataArray.add(blobResponseData);
 //                    cellDataForResponse = _rs.getBytes(col);
                 }

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -141,7 +141,7 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                 } else if (cellData instanceof Blob){
                     String id = this.getId();
                     InputStream is = _rs.getBinaryStream(col);
-                    m_io.sendResponse(is, id);
+                    m_io.sendResponse(is, id, column);
 
 //                    cellDataForResponse = _rs.getBytes(col);
                 }

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -138,7 +138,7 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                     }
                 } else if (cellData instanceof Number || cellData instanceof Boolean) {
                     cellDataForResponse = cellData;
-                } else if (cellData instanceof AS400JDBCBlobLocator){
+                } else if (cellData instanceof Blob){
                     InputStream is = _rs.getBinaryStream(col);
                     m_io.sendResponse(is);
 

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -110,6 +110,7 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
             return ret.setDone(true);
         }
         final List<BlobResponseData> blobResponseDataArray = new ArrayList<>();
+        int blobsNeeded = 0;
         for (int i = 0; i < _numRows; ++i) {
             if (!_rs.next()) {
                 ret.setDone(true);
@@ -124,7 +125,6 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
             final LinkedHashMap<String, Object> mapRowData = new LinkedHashMap<String, Object>();
             final LinkedList<Object> terseRowData = new LinkedList<Object>();
             final int numCols = _rs.getMetaData().getColumnCount();
-            int blobsNeeded = 0;
             int rowId = i;
             mapRowData.put("rowId", rowId);
             for (int col = 1; col <= numCols; ++col) {

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -134,9 +134,7 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                 } else if (cellData instanceof Number || cellData instanceof Boolean) {
                     cellDataForResponse = cellData;
                 }
-                else if (cellData instanceof Blob){
-                        cellDataForResponse = new String((byte[]) cellData, StandardCharsets.UTF_8);
-                } else {
+                 else {
                     cellDataForResponse = _rs.getString(col);
                 }
                 if (_isTerseDataFormat) {

--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -124,6 +124,7 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
             final LinkedHashMap<String, Object> mapRowData = new LinkedHashMap<String, Object>();
             final LinkedList<Object> terseRowData = new LinkedList<Object>();
             final int numCols = _rs.getMetaData().getColumnCount();
+            int blobsNeeded = 0;
             int rowId = i;
             mapRowData.put("rowId", rowId);
             for (int col = 1; col <= numCols; ++col) {
@@ -141,11 +142,12 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                 } else if (cellData instanceof Number || cellData instanceof Boolean) {
                     cellDataForResponse = cellData;
                 } else if (cellData instanceof Blob){
-                    String id = this.getId();
+                    blobsNeeded++;
                     int blobLength = (int) ((Blob) cellData).length();
 //                    InputStream is = _rs.getBinaryStream(col);
                     BlobResponseData blobResponseData = new BlobResponseData((Blob)cellData, column, rowId, blobLength);
-                    blobResponseDataArray.add(blobResponseData);
+                    m_io.sendResponse(this.getId(), blobResponseData);
+//                    blobResponseDataArray.add(blobResponseData);
 //                    cellDataForResponse = _rs.getBytes(col);
                 }
                  else {
@@ -158,8 +160,11 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
                 }
             }
             ret.add(_isTerseDataFormat ? terseRowData : mapRowData);
+            Map<String, Integer> blobsNeededMap = new HashMap();
+            blobsNeededMap.put("blobsNeeded", blobsNeeded);
+            ret.add(blobsNeededMap);
         }
-        m_io.sendResponse(this.getId(), blobResponseDataArray);
+//        m_io.sendResponse(this.getId(), blobResponseDataArray);
         return ret;
     }
 

--- a/src/main/java/com/github/ibm/mapepire/requests/Exit.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/Exit.java
@@ -21,7 +21,7 @@ public class Exit extends ClientRequest {
     @Override
     protected void processAfterReplySent() {
         if (DbSocketCreator.isDaemon()) {
-            this.getConnection().close();
+            this.getSystemConnection().close();
         } else {
             Tracer.info("exiting as requested");
             System.exit(0);

--- a/src/main/java/com/github/ibm/mapepire/requests/PrepareSql.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/PrepareSql.java
@@ -20,11 +20,13 @@ public class PrepareSql extends BlockRetrievableRequest {
     private PreparedStatement m_stmt = null;
     private final PreparedExecute m_executeTask;
     private int blobsNeeded = 0;
+    private final boolean isImmediateExecute;
 
     public PrepareSql(final DataStreamProcessor _io, final SystemConnection m_conn, final JsonObject _reqObj,
             final boolean _isImmediateExecute) {
         super(_io, m_conn, _reqObj);
-        m_executeTask = _isImmediateExecute ? new PreparedExecute(_io, _reqObj, this) : null;
+        this.isImmediateExecute = _isImmediateExecute;
+        m_executeTask = new PreparedExecute(_io, _reqObj, this);
         this.blobsNeeded = getRequestFieldInt("blobsNeeded", 0);
     }
 
@@ -85,7 +87,7 @@ public class PrepareSql extends BlockRetrievableRequest {
         }
 
         addReplyData("metadata", metaData);
-        if (null != m_executeTask) {
+        if (isImmediateExecute) {
             executeTask();
         }
     }
@@ -121,7 +123,7 @@ public class PrepareSql extends BlockRetrievableRequest {
     }
     @Override
     public boolean isDone() {
-        if(null != m_executeTask) {
+        if (null != m_executeTask) {
             return m_isDone || m_executeTask.isDone();
         }
         // This means that the request was _only_ for a prepare, so yes we're done if we haven't fetched any data

--- a/src/main/java/com/github/ibm/mapepire/requests/PrepareSql.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/PrepareSql.java
@@ -19,11 +19,21 @@ public class PrepareSql extends BlockRetrievableRequest {
 
     private PreparedStatement m_stmt = null;
     private final PreparedExecute m_executeTask;
+    private int blobsNeeded = 0;
 
     public PrepareSql(final DataStreamProcessor _io, final SystemConnection m_conn, final JsonObject _reqObj,
             final boolean _isImmediateExecute) {
         super(_io, m_conn, _reqObj);
         m_executeTask = _isImmediateExecute ? new PreparedExecute(_io, _reqObj, this) : null;
+        this.blobsNeeded = getRequestFieldInt("blobsNeeded", 0);
+    }
+
+    public int getBlobsNeeded() {
+        return blobsNeeded;
+    }
+
+    public void setBlobsNeeded(int blobsNeeded) {
+        this.blobsNeeded = blobsNeeded;
     }
 
     @Override

--- a/src/main/java/com/github/ibm/mapepire/requests/PrepareSql.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/PrepareSql.java
@@ -32,6 +32,10 @@ public class PrepareSql extends BlockRetrievableRequest {
         return blobsNeeded;
     }
 
+    public PreparedExecute getM_executeTask(){
+        return m_executeTask;
+    }
+
     public void setBlobsNeeded(int blobsNeeded) {
         this.blobsNeeded = blobsNeeded;
     }
@@ -82,10 +86,14 @@ public class PrepareSql extends BlockRetrievableRequest {
 
         addReplyData("metadata", metaData);
         if (null != m_executeTask) {
-            m_executeTask.go();
-            this.m_rs = m_executeTask.m_rs;
-            mergeReplyData(m_executeTask);
+            executeTask();
         }
+    }
+
+    public void executeTask() throws Exception {
+        m_executeTask.go();
+        this.m_rs = m_executeTask.m_rs;
+        mergeReplyData(m_executeTask);
     }
 
     private static String getDb2ParameterName(PreparedStatement _stmt, int _i) throws SQLException {

--- a/src/main/java/com/github/ibm/mapepire/requests/PreparedExecute.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/PreparedExecute.java
@@ -1,11 +1,20 @@
 package com.github.ibm.mapepire.requests;
 
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.math.BigDecimal;
 import java.sql.CallableStatement;
 import java.sql.ParameterMetaData;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+
+
 import java.sql.Types;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.LinkedList;
 
 import com.github.ibm.mapepire.DataStreamProcessor;
@@ -25,6 +34,7 @@ public class PreparedExecute extends BlockRetrievableRequest {
     @Override
     protected void go() throws Exception {
         JsonArray parms = super.getRequestField("parameters").getAsJsonArray();
+        JsonArray columnTypes = super.getRequestField("columnTypes").getAsJsonArray();
         boolean isBatch = !parms.isEmpty() && parms.get(0).isJsonArray();
         boolean hasResultSet = false;
         long batchUpdateCount = 0;
@@ -34,7 +44,7 @@ public class PreparedExecute extends BlockRetrievableRequest {
             JsonArray arr = parms.getAsJsonArray();
             int batch_ops_added = 0;
             for (int i = 0; i < arr.size(); i++) {
-                addJsonArrayParameters(stmt, arr.get(i).getAsJsonArray());
+                addJsonArrayParameters(stmt, arr.get(i).getAsJsonArray(), columnTypes);
                 m_prev.getStatement().addBatch();
             }
             batch_ops_added += arr.size();
@@ -43,7 +53,7 @@ public class PreparedExecute extends BlockRetrievableRequest {
             batchUpdateCount = Arrays.stream(updateCount).sum();
         } else{
             if (parms != null) {
-                addJsonArrayParameters(stmt, parms.getAsJsonArray());
+                addJsonArrayParameters(stmt, parms.getAsJsonArray(), columnTypes);
             }
             hasResultSet = stmt.execute();
         }
@@ -66,9 +76,87 @@ public class PreparedExecute extends BlockRetrievableRequest {
         }
     }
 
-    private void addJsonArrayParameters(PreparedStatement stmt, JsonArray arr) throws SQLException {
-        for (int i = 1; i <= arr.size(); ++i) {
-            JsonElement element = arr.get(-1 + i);
+    private void addParameter(int i, JsonElement parameter, ColumnType columnType, PreparedStatement stmt) throws SQLException {
+        String stringValue = parameter.getAsString();
+
+        switch (columnType) {
+            case BLOB: {
+                byte[] decodedBytes = Base64.getDecoder().decode(stringValue);
+                ByteArrayInputStream blob = new ByteArrayInputStream(decodedBytes);
+                stmt.setBlob(i, blob);
+                break;
+            }
+            case CLOB:
+                stmt.setClob(i, new StringReader(stringValue));
+                break;
+            case INTEGER:
+                stmt.setInt(i, Integer.parseInt(stringValue));
+                break;
+            case BIGINT:
+                stmt.setLong(i, Long.parseLong(stringValue));
+                break;
+            case SMALLINT:
+                stmt.setShort(i, Short.parseShort(stringValue));
+                break;
+            case DOUBLE:
+                stmt.setDouble(i, Double.parseDouble(stringValue));
+                break;
+            case FLOAT:
+                stmt.setFloat(i, Float.parseFloat(stringValue));
+                break;
+            case DECIMAL:
+                stmt.setBigDecimal(i, new BigDecimal(stringValue));
+                break;
+            case DATE:
+                stmt.setDate(i, Date.valueOf(stringValue)); // expects ISO format: yyyy-[m]m-[d]d
+                break;
+            case TIME:
+                stmt.setTime(i, Time.valueOf(stringValue)); // expects format: hh:mm:ss
+                break;
+            case TIMESTAMP:
+                stmt.setTimestamp(i, Timestamp.valueOf(stringValue)); // expects format: yyyy-[m]m-[d]d hh:mm:ss[.f...]
+                break;
+            case BOOLEAN:
+                stmt.setBoolean(i, Boolean.parseBoolean(stringValue));
+                break;
+            default:
+                stmt.setString(i, stringValue); // Fallback
+        }
+    }
+
+
+    public enum ColumnType {
+        CHAR,
+        VARCHAR,
+        INTEGER,
+        FLOAT,
+        DECIMAL,
+        DATE,
+        TIME,
+        TIMESTAMP,
+        CLOB,
+        BLOB,
+        BOOLEAN,
+        SMALLINT,
+        BIGINT,
+        DOUBLE
+    }
+
+    private ColumnType getColumnType(int i, JsonArray columnTypes){
+        ColumnType columnType;
+        try {
+            columnType = ColumnType.valueOf(columnTypes.get(-1 + i).getAsString());
+        } catch (IllegalArgumentException e){
+            columnType = ColumnType.VARCHAR;
+        }
+        return columnType;
+    }
+
+    private void addJsonArrayParameters(PreparedStatement stmt, JsonArray parameters, JsonArray columnTypes) throws SQLException {
+        for (int i = 1; i <= parameters.size(); ++i) {
+            JsonElement element = parameters.get(-1 + i);
+            ColumnType columnType = getColumnType(-1 + i, columnTypes);
+
             if (element.isJsonNull()) {
                 stmt.setNull(i, Types.NULL);
             } else {
@@ -78,9 +166,9 @@ public class PreparedExecute extends BlockRetrievableRequest {
                 } else if (stmt instanceof CallableStatement
                         && ParameterMetaData.parameterModeInOut == stmt.getParameterMetaData().getParameterMode(i)) {
                     ((CallableStatement) stmt).registerOutParameter(i, stmt.getParameterMetaData().getParameterType(i));
-                    stmt.setString(i, element.getAsString());
+                    addParameter(i, element, columnType, stmt);
                 } else {
-                    stmt.setString(i, element.getAsString());
+                    addParameter(i, element, columnType, stmt);
                 }
             }
         }

--- a/src/main/java/com/github/ibm/mapepire/requests/PreparedExecute.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/PreparedExecute.java
@@ -36,7 +36,7 @@ public class PreparedExecute extends BlockRetrievableRequest {
         JsonArray parms = super.getRequestField("parameters").getAsJsonArray();
         JsonElement columnTypesElement = super.getRequestField("columnTypes");
         JsonArray columnTypes;
-        if (!columnTypesElement.isJsonNull()){
+        if (columnTypesElement != null){
             columnTypes = columnTypesElement.getAsJsonArray();
         } else {
             columnTypes = null;

--- a/src/main/java/com/github/ibm/mapepire/requests/PreparedExecute.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/PreparedExecute.java
@@ -145,7 +145,7 @@ public class PreparedExecute extends BlockRetrievableRequest {
     private ColumnType getColumnType(int i, JsonArray columnTypes){
         ColumnType columnType;
         try {
-            columnType = ColumnType.valueOf(columnTypes.get(-1 + i).getAsString());
+            columnType = ColumnType.valueOf(columnTypes.get(i).getAsString());
         } catch (IllegalArgumentException e){
             columnType = ColumnType.VARCHAR;
         }

--- a/src/main/java/com/github/ibm/mapepire/requests/PreparedExecute.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/PreparedExecute.java
@@ -34,7 +34,13 @@ public class PreparedExecute extends BlockRetrievableRequest {
     @Override
     protected void go() throws Exception {
         JsonArray parms = super.getRequestField("parameters").getAsJsonArray();
-        JsonArray columnTypes = super.getRequestField("columnTypes").getAsJsonArray();
+        JsonElement columnTypesElement = super.getRequestField("columnTypes");
+        JsonArray columnTypes;
+        if (!columnTypesElement.isJsonNull()){
+            columnTypes = columnTypesElement.getAsJsonArray();
+        } else {
+            columnTypes = null;
+        }
         boolean isBatch = !parms.isEmpty() && parms.get(0).isJsonArray();
         boolean hasResultSet = false;
         long batchUpdateCount = 0;
@@ -155,7 +161,7 @@ public class PreparedExecute extends BlockRetrievableRequest {
     private void addJsonArrayParameters(PreparedStatement stmt, JsonArray parameters, JsonArray columnTypes) throws SQLException {
         for (int i = 1; i <= parameters.size(); ++i) {
             JsonElement element = parameters.get(-1 + i);
-            ColumnType columnType = getColumnType(-1 + i, columnTypes);
+            ColumnType columnType = columnTypes == null ? ColumnType.VARCHAR : getColumnType(-1 + i, columnTypes);
 
             if (element.isJsonNull()) {
                 stmt.setNull(i, Types.NULL);

--- a/src/main/java/com/github/ibm/mapepire/requests/RunBlob.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/RunBlob.java
@@ -1,11 +1,14 @@
 package com.github.ibm.mapepire.requests;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.sql.*;
 import java.util.Arrays;
 import java.util.LinkedList;
+import java.util.List;
 
+import com.github.ibm.mapepire.BlobRequestData;
 import com.github.ibm.mapepire.DataStreamProcessor;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -17,80 +20,16 @@ public class RunBlob{
 
     private final PrepareSql m_prev;
 
-    public RunBlob(final DataStreamProcessor _io, final byte[] binary, final int offset, final int length, final PrepareSql _prev) throws SQLException {
+    public RunBlob(final byte[] binary, final List<BlobRequestData> blobRequestDataList, final PrepareSql _prev) throws SQLException {
         m_prev = _prev;
         PreparedStatement stmt = m_prev.getStatement();
-        try (InputStream is = new ByteArrayInputStream(binary, offset, length)) {
-            stmt.setBinaryStream(1, is, length);
-            int affectedRows = stmt.executeUpdate();
+        for (BlobRequestData blobRequestData: blobRequestDataList){
+            int offset = blobRequestData.getOffset();
+            int length = blobRequestData.getLength();
+            int replacementIndex = blobRequestData.getReplacementIndex();
+            InputStream is = new ByteArrayInputStream(binary, offset, length);
+            stmt.setBinaryStream(replacementIndex, is, length);
         }
-        catch (Exception e){
-            System.out.println("Caught error " + e);
-        }
-
+        stmt.execute();
     }
-
-//    @Override
-//    protected void go() throws Exception {
-//        boolean isBatch = !parms.isEmpty() && parms.get(0).isJsonArray();
-//        boolean hasResultSet = false;
-//        long batchUpdateCount = 0;
-//
-//        PreparedStatement stmt = m_prev.getStatement();
-//        if (isBatch) {
-//            JsonArray arr = parms.getAsJsonArray();
-//            int batch_ops_added = 0;
-//            for (int i = 0; i < arr.size(); i++) {
-//                addJsonArrayParameters(stmt, arr.get(i).getAsJsonArray());
-//                m_prev.getStatement().addBatch();
-//            }
-//            batch_ops_added += arr.size();
-//            addReplyData("batch_added", batch_ops_added);
-//            long updateCount[] = stmt.executeLargeBatch();
-//            batchUpdateCount = Arrays.stream(updateCount).sum();
-//        } else{
-//            if (parms != null) {
-//                addJsonArrayParameters(stmt, parms.getAsJsonArray());
-//            }
-//            hasResultSet = stmt.execute();
-//        }
-//
-//        if (hasResultSet) {
-//            this.m_rs = stmt.getResultSet();
-//            final int numRows = super.getRequestFieldInt("rows", 1000);
-//            addReplyData("has_results", true);
-//            addReplyData("update_count", stmt.getLargeUpdateCount());
-//            addReplyData("metadata", getResultMetaDataForResponse());
-//            addReplyData("data", getNextDataBlock(numRows));
-//            addReplyData("output_parms", getOutputParms(stmt));
-//            addReplyData("is_done", isDone());
-//        } else {
-//            addReplyData("data", new LinkedList<Object>());
-//            addReplyData("has_results", false);
-//            addReplyData("update_count", batchUpdateCount != 0 ? batchUpdateCount : stmt.getLargeUpdateCount());
-//            addReplyData("output_parms", getOutputParms(stmt));
-//            addReplyData("is_done", m_isDone = true);
-//        }
-//    }
-
-    private void addJsonArrayParameters(PreparedStatement stmt, JsonArray arr) throws SQLException {
-        for (int i = 1; i <= arr.size(); ++i) {
-            JsonElement element = arr.get(-1 + i);
-            if (element.isJsonNull()) {
-                stmt.setNull(i, Types.NULL);
-            } else {
-                if (stmt instanceof CallableStatement
-                        && ParameterMetaData.parameterModeOut == stmt.getParameterMetaData().getParameterMode(i)) {
-                    ((CallableStatement) stmt).registerOutParameter(i, stmt.getParameterMetaData().getParameterType(i));
-                } else if (stmt instanceof CallableStatement
-                        && ParameterMetaData.parameterModeInOut == stmt.getParameterMetaData().getParameterMode(i)) {
-                    ((CallableStatement) stmt).registerOutParameter(i, stmt.getParameterMetaData().getParameterType(i));
-                    stmt.setString(i, element.getAsString());
-                } else {
-                    stmt.setString(i, element.getAsString());
-                }
-            }
-        }
-    }
-
 }

--- a/src/main/java/com/github/ibm/mapepire/requests/RunBlob.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/RunBlob.java
@@ -19,11 +19,9 @@ public class RunBlob{
         m_prev = _prev;
         PreparedStatement stmt = m_prev.getStatement();
         Blob blob = new SerialBlob(binary);
-//        stmt.setString(i, element.getAsString());
-        stmt.setBlob(0, blob);
-
+        stmt.setBlob(1, blob);
         try {
-            stmt.getResultSet();
+            int affectedRows = stmt.executeUpdate();
 
         } catch (Exception e){
             System.out.println("Caught error " + e);

--- a/src/main/java/com/github/ibm/mapepire/requests/RunBlob.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/RunBlob.java
@@ -1,5 +1,7 @@
 package com.github.ibm.mapepire.requests;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.sql.*;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -18,12 +20,11 @@ public class RunBlob{
     public RunBlob(final DataStreamProcessor _io, final byte[] binary, final PrepareSql _prev) throws SQLException {
         m_prev = _prev;
         PreparedStatement stmt = m_prev.getStatement();
-        Blob blob = new SerialBlob(binary);
-        stmt.setBlob(1, blob);
-        try {
+        try (InputStream is = new ByteArrayInputStream(binary)) {
+            stmt.setBinaryStream(1, is, binary.length);
             int affectedRows = stmt.executeUpdate();
-
-        } catch (Exception e){
+        }
+        catch (Exception e){
             System.out.println("Caught error " + e);
         }
 

--- a/src/main/java/com/github/ibm/mapepire/requests/RunBlob.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/RunBlob.java
@@ -20,7 +20,7 @@ public class RunBlob{
 
     private final PrepareSql m_prev;
 
-    public RunBlob(final byte[] binary, final List<BlobRequestData> blobRequestDataList, final PrepareSql _prev) throws SQLException {
+    public RunBlob(final byte[] binary, final List<BlobRequestData> blobRequestDataList, final PrepareSql _prev) throws Exception {
         m_prev = _prev;
         PreparedStatement stmt = m_prev.getStatement();
         for (BlobRequestData blobRequestData: blobRequestDataList){
@@ -29,7 +29,8 @@ public class RunBlob{
             int replacementIndex = blobRequestData.getReplacementIndex();
             InputStream is = new ByteArrayInputStream(binary, offset, length);
             stmt.setBinaryStream(replacementIndex, is, length);
+
         }
-        stmt.execute();
+        _prev.executeTask();
     }
 }

--- a/src/main/java/com/github/ibm/mapepire/requests/RunBlob.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/RunBlob.java
@@ -22,7 +22,12 @@ public class RunBlob{
 //        stmt.setString(i, element.getAsString());
         stmt.setBlob(0, blob);
 
-        stmt.getResultSet();
+        try {
+            stmt.getResultSet();
+
+        } catch (Exception e){
+            System.out.println("Caught error " + e);
+        }
 
     }
 

--- a/src/main/java/com/github/ibm/mapepire/requests/RunBlob.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/RunBlob.java
@@ -1,0 +1,92 @@
+package com.github.ibm.mapepire.requests;
+
+import java.sql.*;
+import java.util.Arrays;
+import java.util.LinkedList;
+
+import com.github.ibm.mapepire.DataStreamProcessor;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import javax.sql.rowset.serial.SerialBlob;
+
+public class RunBlob{
+
+    private final PrepareSql m_prev;
+
+    public RunBlob(final DataStreamProcessor _io, final byte[] binary, final PrepareSql _prev) throws SQLException {
+        m_prev = _prev;
+        PreparedStatement stmt = m_prev.getStatement();
+        Blob blob = new SerialBlob(binary);
+//        stmt.setString(i, element.getAsString());
+        stmt.setBlob(0, blob);
+
+        stmt.getResultSet();
+
+    }
+
+//    @Override
+//    protected void go() throws Exception {
+//        boolean isBatch = !parms.isEmpty() && parms.get(0).isJsonArray();
+//        boolean hasResultSet = false;
+//        long batchUpdateCount = 0;
+//
+//        PreparedStatement stmt = m_prev.getStatement();
+//        if (isBatch) {
+//            JsonArray arr = parms.getAsJsonArray();
+//            int batch_ops_added = 0;
+//            for (int i = 0; i < arr.size(); i++) {
+//                addJsonArrayParameters(stmt, arr.get(i).getAsJsonArray());
+//                m_prev.getStatement().addBatch();
+//            }
+//            batch_ops_added += arr.size();
+//            addReplyData("batch_added", batch_ops_added);
+//            long updateCount[] = stmt.executeLargeBatch();
+//            batchUpdateCount = Arrays.stream(updateCount).sum();
+//        } else{
+//            if (parms != null) {
+//                addJsonArrayParameters(stmt, parms.getAsJsonArray());
+//            }
+//            hasResultSet = stmt.execute();
+//        }
+//
+//        if (hasResultSet) {
+//            this.m_rs = stmt.getResultSet();
+//            final int numRows = super.getRequestFieldInt("rows", 1000);
+//            addReplyData("has_results", true);
+//            addReplyData("update_count", stmt.getLargeUpdateCount());
+//            addReplyData("metadata", getResultMetaDataForResponse());
+//            addReplyData("data", getNextDataBlock(numRows));
+//            addReplyData("output_parms", getOutputParms(stmt));
+//            addReplyData("is_done", isDone());
+//        } else {
+//            addReplyData("data", new LinkedList<Object>());
+//            addReplyData("has_results", false);
+//            addReplyData("update_count", batchUpdateCount != 0 ? batchUpdateCount : stmt.getLargeUpdateCount());
+//            addReplyData("output_parms", getOutputParms(stmt));
+//            addReplyData("is_done", m_isDone = true);
+//        }
+//    }
+
+    private void addJsonArrayParameters(PreparedStatement stmt, JsonArray arr) throws SQLException {
+        for (int i = 1; i <= arr.size(); ++i) {
+            JsonElement element = arr.get(-1 + i);
+            if (element.isJsonNull()) {
+                stmt.setNull(i, Types.NULL);
+            } else {
+                if (stmt instanceof CallableStatement
+                        && ParameterMetaData.parameterModeOut == stmt.getParameterMetaData().getParameterMode(i)) {
+                    ((CallableStatement) stmt).registerOutParameter(i, stmt.getParameterMetaData().getParameterType(i));
+                } else if (stmt instanceof CallableStatement
+                        && ParameterMetaData.parameterModeInOut == stmt.getParameterMetaData().getParameterMode(i)) {
+                    ((CallableStatement) stmt).registerOutParameter(i, stmt.getParameterMetaData().getParameterType(i));
+                    stmt.setString(i, element.getAsString());
+                } else {
+                    stmt.setString(i, element.getAsString());
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/github/ibm/mapepire/requests/RunBlob.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/RunBlob.java
@@ -17,11 +17,11 @@ public class RunBlob{
 
     private final PrepareSql m_prev;
 
-    public RunBlob(final DataStreamProcessor _io, final byte[] binary, final PrepareSql _prev) throws SQLException {
+    public RunBlob(final DataStreamProcessor _io, final byte[] binary, final int offset, final int length, final PrepareSql _prev) throws SQLException {
         m_prev = _prev;
         PreparedStatement stmt = m_prev.getStatement();
-        try (InputStream is = new ByteArrayInputStream(binary)) {
-            stmt.setBinaryStream(1, is, binary.length);
+        try (InputStream is = new ByteArrayInputStream(binary, offset, length)) {
+            stmt.setBinaryStream(1, is, length);
             int affectedRows = stmt.executeUpdate();
         }
         catch (Exception e){

--- a/src/main/java/com/github/ibm/mapepire/ws/AsyncSender.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/AsyncSender.java
@@ -1,0 +1,33 @@
+package com.github.ibm.mapepire.ws;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.RemoteEndpoint;
+import org.eclipse.jetty.websocket.api.WebSocketAdapter;
+
+public class AsyncSender {
+    private final ExecutorService executor = Executors.newFixedThreadPool(1);
+    private final WebSocketAdapter session;
+
+    public AsyncSender(WebSocketAdapter session) {
+        this.session = session;
+    }
+
+    public void send(ByteBuffer buffer, boolean isLast) {
+        executor.submit(() -> {
+            try {
+                RemoteEndpoint remote = session.getRemote();
+                remote.sendPartialBytes(buffer, isLast);
+            } catch (Exception e) {
+                e.printStackTrace(); // or better logging
+            }
+        });
+    }
+
+    public void shutdown() {
+        executor.shutdown();
+    }
+}

--- a/src/main/java/com/github/ibm/mapepire/ws/AsyncSender.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/AsyncSender.java
@@ -1,6 +1,8 @@
 package com.github.ibm.mapepire.ws;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -17,14 +19,20 @@ public class AsyncSender {
     }
 
     public void send(ByteBuffer buffer, boolean isLast) {
-        executor.submit(() -> {
-            try {
+        try {
+
+            executor.submit(() -> {
                 RemoteEndpoint remote = session.getRemote();
-                remote.sendPartialBytes(buffer, isLast);
-            } catch (Exception e) {
-                e.printStackTrace(); // or better logging
+                try {
+                    remote.sendPartialBytes(buffer, isLast);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
-        });
+        ).get();}
+            catch (Exception e) {
+            e.printStackTrace(); // or better logging
+        }
     }
 
     public void shutdown() {

--- a/src/main/java/com/github/ibm/mapepire/ws/BinarySender.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/BinarySender.java
@@ -1,0 +1,9 @@
+package com.github.ibm.mapepire.ws;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+@FunctionalInterface
+public interface BinarySender {
+    void send(ByteBuffer buffer, boolean isLast) throws IOException;
+}

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -38,8 +38,8 @@ public class DbWebsocketClient extends WebSocketAdapter {
   public void onWebSocketBinary(byte[] payload, int offset, int len) {
     System.out.println(">>> onWebSocketBinary called with len=" + len);
     // Access only the relevant portion of the data
-    byte[] binary = Arrays.copyOfRange(payload, offset, offset + len);
-    io.run(binary);
+//    byte[] binary = Arrays.copyOfRange(payload, offset, offset + len);
+    io.run(payload, offset, len);
 
     // Now use `message` as needed
   }

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -14,7 +14,6 @@ import java.util.concurrent.CountDownLatch;
 public class DbWebsocketClient extends WebSocketAdapter {
   private final CountDownLatch closureLatch = new CountDownLatch(1);
   private final DataStreamProcessor io;
-  private final RemoteEndpoint remote;
 
   @FunctionalInterface
   public interface BinarySender {
@@ -70,7 +69,7 @@ public class DbWebsocketClient extends WebSocketAdapter {
   }
 
   private DataStreamProcessor getDataStreamProcessor(DbWebsocketClient endpoint, SystemConnection conn) throws UnsupportedEncodingException {
-    BinarySender binarySender = (data, isLast) -> remote.sendPartialBytes(data, isLast);
+    BinarySender binarySender = (data, isLast) -> getRemote().sendPartialBytes(data, isLast);
     InputStream in = new ByteArrayInputStream(new byte[0]);
 
     OutputStream outStreamText = new OutputStream() {

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -8,6 +8,7 @@ import org.eclipse.jetty.websocket.api.WebSocketException;
 
 import java.io.*;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 
 public class DbWebsocketClient extends WebSocketAdapter {
@@ -31,6 +32,15 @@ public class DbWebsocketClient extends WebSocketAdapter {
   public void onWebSocketText(String message) {
     super.onWebSocketText(message);
     io.run(message);
+  }
+
+  @Override
+  public void onWebSocketBinary(byte[] payload, int offset, int len) {
+    // Access only the relevant portion of the data
+    byte[] binary = Arrays.copyOfRange(payload, offset, offset + len);
+    io.run(binary);
+
+    // Now use `message` as needed
   }
 
   @Override

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -36,6 +36,7 @@ public class DbWebsocketClient extends WebSocketAdapter {
 
   @Override
   public void onWebSocketBinary(byte[] payload, int offset, int len) {
+    System.out.println(">>> onWebSocketBinary called with len=" + len);
     // Access only the relevant portion of the data
     byte[] binary = Arrays.copyOfRange(payload, offset, offset + len);
     io.run(binary);

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -22,7 +22,6 @@ public class DbWebsocketClient extends WebSocketAdapter {
 
   DbWebsocketClient(String clientHost, String clientAddress, String host, String user, String pass) throws IOException {
     super();
-    remote = getRemote();
     SystemConnection conn = new SystemConnection(clientHost, clientAddress,host, user, pass);
     io = getDataStreamProcessor(this, conn);
   }

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -70,15 +70,8 @@ public class DbWebsocketClient extends WebSocketAdapter {
 
   private DataStreamProcessor getDataStreamProcessor(DbWebsocketClient endpoint, SystemConnection conn) throws UnsupportedEncodingException {
 //    BinarySender binarySender = (data, isLast) -> getRemote().sendPartialBytes(data, isLast);
-    BinarySender binarySender = (data, isLast) -> {
-      new Thread(() -> {
-        try {
-          getRemote().sendPartialBytes(data, isLast);
-        } catch (IOException e) {
-          e.printStackTrace();
-        }
-      }).start();
-    };
+    AsyncSender asyncSender = new AsyncSender(this);
+
     InputStream in = new ByteArrayInputStream(new byte[0]);
 
     OutputStream outStreamText = new OutputStream() {
@@ -111,6 +104,6 @@ public class DbWebsocketClient extends WebSocketAdapter {
 
     PrintStream out = new PrintStream(outStreamText);
 
-    return new DataStreamProcessor(in, out, binarySender, conn, false);
+    return new DataStreamProcessor(in, out, asyncSender, conn, false);
   }
 }

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -10,15 +10,16 @@ import org.eclipse.jetty.websocket.api.WebSocketException;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
+import com.github.ibm.mapepire.ws.BinarySender;
 
 public class DbWebsocketClient extends WebSocketAdapter {
   private final CountDownLatch closureLatch = new CountDownLatch(1);
   private final DataStreamProcessor io;
 
-  @FunctionalInterface
+ /* @FunctionalInterface
   public interface BinarySender {
     void send(ByteBuffer buffer, boolean isLast) throws IOException;
-  }
+  }*/
 
   DbWebsocketClient(String clientHost, String clientAddress, String host, String user, String pass) throws IOException {
     super();

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -38,7 +38,7 @@ public class DbWebsocketClient extends WebSocketAdapter {
   public void onWebSocketBinary(byte[] payload, int offset, int len) {
     System.out.println(">>> onWebSocketBinary called with len=" + len);
     // Access only the relevant portion of the data
-    byte[] binary = Arrays.copyOfRange(payload, offset, offset + len);
+    byte[] binary = Arrays.copyOfRange(payload, offset, offset + len - 1);
     io.run(binary);
 
     // Now use `message` as needed

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -2,24 +2,16 @@ package com.github.ibm.mapepire.ws;
 
 import com.github.ibm.mapepire.DataStreamProcessor;
 import com.github.ibm.mapepire.SystemConnection;
-import org.eclipse.jetty.websocket.api.RemoteEndpoint;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.WebSocketAdapter;
 import org.eclipse.jetty.websocket.api.WebSocketException;
 
 import java.io.*;
-import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
-import com.github.ibm.mapepire.ws.BinarySender;
 
 public class DbWebsocketClient extends WebSocketAdapter {
   private final CountDownLatch closureLatch = new CountDownLatch(1);
   private final DataStreamProcessor io;
-
- /* @FunctionalInterface
-  public interface BinarySender {
-    void send(ByteBuffer buffer, boolean isLast) throws IOException;
-  }*/
 
   DbWebsocketClient(String clientHost, String clientAddress, String host, String user, String pass) throws IOException {
     super();
@@ -42,12 +34,7 @@ public class DbWebsocketClient extends WebSocketAdapter {
 
   @Override
   public void onWebSocketBinary(byte[] payload, int offset, int len) {
-    System.out.println(">>> onWebSocketBinary called with len=" + len);
-    // Access only the relevant portion of the data
-//    byte[] binary = Arrays.copyOfRange(payload, offset, offset + len);
     io.run(payload, offset, len);
-
-    // Now use `message` as needed
   }
 
   @Override
@@ -69,7 +56,6 @@ public class DbWebsocketClient extends WebSocketAdapter {
   }
 
   private DataStreamProcessor getDataStreamProcessor(DbWebsocketClient endpoint, SystemConnection conn) throws UnsupportedEncodingException {
-//    BinarySender binarySender = (data, isLast) -> getRemote().sendPartialBytes(data, isLast);
     AsyncSender asyncSender = new AsyncSender(this);
 
     InputStream in = new ByteArrayInputStream(new byte[0]);

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -38,7 +38,7 @@ public class DbWebsocketClient extends WebSocketAdapter {
   public void onWebSocketBinary(byte[] payload, int offset, int len) {
     System.out.println(">>> onWebSocketBinary called with len=" + len);
     // Access only the relevant portion of the data
-    byte[] binary = Arrays.copyOfRange(payload, offset, offset + len - 1);
+    byte[] binary = Arrays.copyOfRange(payload, offset, offset + len);
     io.run(binary);
 
     // Now use `message` as needed

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -69,7 +69,16 @@ public class DbWebsocketClient extends WebSocketAdapter {
   }
 
   private DataStreamProcessor getDataStreamProcessor(DbWebsocketClient endpoint, SystemConnection conn) throws UnsupportedEncodingException {
-    BinarySender binarySender = (data, isLast) -> getRemote().sendPartialBytes(data, isLast);
+//    BinarySender binarySender = (data, isLast) -> getRemote().sendPartialBytes(data, isLast);
+    BinarySender binarySender = (data, isLast) -> {
+      new Thread(() -> {
+        try {
+          getRemote().sendPartialBytes(data, isLast);
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
+      }).start();
+    };
     InputStream in = new ByteArrayInputStream(new byte[0]);
 
     OutputStream outStreamText = new OutputStream() {

--- a/src/test/java/BlobTest.java
+++ b/src/test/java/BlobTest.java
@@ -480,6 +480,9 @@ public class BlobTest {
                 0,0,0,0,  // row id
                 4, 98, 108, 111, 98, // col name length, colname
                 0, 80, 0, 0, 0, 1, 2, 3, 4, 5}; // blob length, blob
+
+        byte[] expectedResult2 = {
+                -19, -18, -17, -16, -15}; // blob length, blob
         Blob blob = new SerialBlob(blobData);
 
         // Use rowsByIndex to support getBinaryStream(int columnIndex)
@@ -523,8 +526,12 @@ public class BlobTest {
         block.getNextDataBlockUsage(rs, 1, false);
 
         byte[] actualFirst21 = Arrays.copyOfRange(capturedBuffers.get(0), 0, 25);
+        byte[] actualSecondBuf = Arrays.copyOfRange(capturedBuffers.get(1), 0, 5);
+
 
         assertArrayEquals(expectedResult, actualFirst21);
+        assertArrayEquals(expectedResult2, actualSecondBuf);
+
         assertFalse(capturedFlags.get(0));
 
 

--- a/src/test/java/BlobTest.java
+++ b/src/test/java/BlobTest.java
@@ -130,7 +130,7 @@ public class BlobTest {
 
         BlockRetrievableRequestImpl block = new BlockRetrievableRequestImpl(io, null, obj);
         byte[] blobData = {1, 2, 3, 4, 5};
-        byte[] expectedResult = {5, 49, 50, 51, 52, 53, 0, 4, 98, 108, 111, 98, 0,0,0,5, 1, 2, 3, 4, 5}; // queryIdLength | queryId | rowId | colNameLength | colName| bloblLength| blob
+        byte[] expectedResult = {5, 49, 50, 51, 52, 53, 0,0,0,0, 4, 98, 108, 111, 98, 0,0,0,5, 1, 2, 3, 4, 5}; // queryIdLength | queryId | rowId | colNameLength | colName| bloblLength| blob
         Blob blob = new SerialBlob(blobData);
 
         // Use rowsByIndex to support getBinaryStream(int columnIndex)
@@ -171,8 +171,8 @@ public class BlobTest {
         byte[] blob1Data = {1, 2, 3, 4, 5};
         byte[] blob2Data = {6, 7, 8};
 
-        byte[] expectedResult1 = {5, 49, 50, 51, 52, 53, 0, 4, 98, 108, 111, 98, 0,0,0,5, 1, 2, 3, 4, 5}; // queryIdLength | queryId | rowId | colNameLength | colName| bloblLength| blob
-        byte[] expectedResult2 = {1, 4, 98, 108, 111, 98, 0,0,0,3, 6, 7, 8}; //  rowId | colNameLength | colName| bloblLength| blob
+        byte[] expectedResult1 = {5, 49, 50, 51, 52, 53, 0,0,0,0, 4, 98, 108, 111, 98, 0,0,0,5, 1, 2, 3, 4, 5}; // queryIdLength | queryId | rowId | colNameLength | colName| bloblLength| blob
+        byte[] expectedResult2 = {0,0,0,1, 4, 98, 108, 111, 98, 0,0,0,3, 6, 7, 8}; //  rowId | colNameLength | colName| bloblLength| blob
 
         Blob blob1 = new SerialBlob(blob1Data);
         Blob blob2 = new SerialBlob(blob2Data);
@@ -234,13 +234,13 @@ public class BlobTest {
 
         byte[] expected1 = {
                 3, '1','2','3', // queryId
-                0,              // rowId
+                0,0,0,0,              // rowId
                 1, 'a',         // colName "a"
                 0,0,0,2, 10, 11,      // blob
         };
 
         byte[] expected2 = {
-                0,              // rowId
+                0,0,0,0,              // rowId
                 2, 'b','b',     // colName "bb"
                 0,0,0,3, 20, 21, 22   // blob
         };
@@ -294,25 +294,25 @@ public class BlobTest {
 
         byte[] expected1 = {
                 6, 'q', 'u', 'e', 'r', 'y', '7', // queryId
-                0,              // rowId
+                0,0,0,0,              // rowId
                 11, 'b', 'l','o','b','C','o','l','u','m','n','1',         // colName "a"
                 0,0,0,5, 1, 2, 3, 4 ,5      // blob
         };
 
         byte[] expected2 = {
-                0,              // rowId
+                0,0,0,0,              // rowId
                 11, 'b', 'l','o','b','C','o','l','u','m','n','2',
                 0,0,0,3, 6, 7, 8   // blob
         };
 
         byte[] expected3 = {
-                1,              // rowId
+                0,0,0,1,              // rowId
                 11, 'b', 'l','o','b','C','o','l','u','m','n','1',
                 0,0,0,5, 1, 2, 3, 4 ,5      // blob
         };
 
         byte[] expected4 = {
-                1,              // rowId
+                0,0,0,1,              // rowId
                 11, 'b', 'l','o','b','C','o','l','u','m','n','2',
                 0,0,0,3, 6, 7, 8   // blob
         };
@@ -421,7 +421,7 @@ public class BlobTest {
         BlockRetrievableRequestImpl block = new BlockRetrievableRequestImpl(io, null, obj);
         byte[] blobData = {1, 2, 3, 4, 5};
         String strCol = "Some string column data";
-        byte[] expectedResult = {5, 49, 50, 51, 52, 53, 0, 4, 98, 108, 111, 98, 0,0,0,5, 1, 2, 3, 4, 5}; // queryIdLength | queryId | rowId | colNameLength | colName| bloblLength| blob
+        byte[] expectedResult = {5, 49, 50, 51, 52, 53, 0,0,0,0, 4, 98, 108, 111, 98, 0,0,0,5, 1, 2, 3, 4, 5}; // queryIdLength | queryId | rowId | colNameLength | colName| bloblLength| blob
         Blob blob = new SerialBlob(blobData);
 
         // Use rowsByIndex to support getBinaryStream(int columnIndex)
@@ -477,7 +477,7 @@ public class BlobTest {
 //        };
         byte[] expectedResult = {
                 5, 49, 50, 51, 52, 53, // querylength, id
-                0,  // row id
+                0,0,0,0,  // row id
                 4, 98, 108, 111, 98, // col name length, colname
                 0, 80, 0, 0, 0, 1, 2, 3, 4, 5}; // blob length, blob
         Blob blob = new SerialBlob(blobData);
@@ -522,7 +522,7 @@ public class BlobTest {
         }).when(binarySender).send(any(ByteBuffer.class), anyBoolean());
         block.getNextDataBlockUsage(rs, 1, false);
 
-        byte[] actualFirst21 = Arrays.copyOfRange(capturedBuffers.get(0), 0, 22);
+        byte[] actualFirst21 = Arrays.copyOfRange(capturedBuffers.get(0), 0, 25);
 
         assertArrayEquals(expectedResult, actualFirst21);
         assertFalse(capturedFlags.get(0));

--- a/src/test/java/BlobTest.java
+++ b/src/test/java/BlobTest.java
@@ -172,7 +172,7 @@ public class BlobTest {
         byte[] blob2Data = {6, 7, 8};
 
         byte[] expectedResult1 = {5, 49, 50, 51, 52, 53, 0,0,0,0, 4, 98, 108, 111, 98, 0,0,0,5, 1, 2, 3, 4, 5}; // queryIdLength | queryId | rowId | colNameLength | colName| bloblLength| blob
-        byte[] expectedResult2 = {0,0,0,1, 4, 98, 108, 111, 98, 0,0,0,3, 6, 7, 8}; //  rowId | colNameLength | colName| bloblLength| blob
+        byte[] expectedResult2 = {5, 49, 50, 51, 52, 53, 0,0,0,1, 4, 98, 108, 111, 98, 0,0,0,3, 6, 7, 8}; //  rowId | colNameLength | colName| bloblLength| blob
 
         Blob blob1 = new SerialBlob(blob1Data);
         Blob blob2 = new SerialBlob(blob2Data);
@@ -205,7 +205,7 @@ public class BlobTest {
         Boolean firstFlag = booleanCaptor.getAllValues().get(0);
         byte[] actual = Arrays.copyOfRange(firstBuf.array(), firstBuf.position(), firstBuf.limit());
         assertArrayEquals(expectedResult1, actual);
-        assertFalse(firstFlag);
+        assertTrue(firstFlag);
 
         // Verify second call
         ByteBuffer secondBuf = bufferCaptor.getAllValues().get(1);
@@ -240,6 +240,7 @@ public class BlobTest {
         };
 
         byte[] expected2 = {
+                3, '1','2','3', // queryId
                 0,0,0,0,              // rowId
                 2, 'b','b',     // colName "bb"
                 0,0,0,3, 20, 21, 22   // blob
@@ -270,7 +271,7 @@ public class BlobTest {
         Boolean firstFlag = booleanCaptor.getAllValues().get(0);
         byte[] actual = Arrays.copyOfRange(firstBuf.array(), firstBuf.position(), firstBuf.limit());
         assertArrayEquals(expected1, actual);
-        assertFalse(firstFlag);
+        assertTrue(firstFlag);
 
         // Verify second call
         ByteBuffer secondBuf = bufferCaptor.getAllValues().get(1);
@@ -300,18 +301,21 @@ public class BlobTest {
         };
 
         byte[] expected2 = {
+                6, 'q', 'u', 'e', 'r', 'y', '7', // queryId
                 0,0,0,0,              // rowId
                 11, 'b', 'l','o','b','C','o','l','u','m','n','2',
                 0,0,0,3, 6, 7, 8   // blob
         };
 
         byte[] expected3 = {
+                6, 'q', 'u', 'e', 'r', 'y', '7', // queryId
                 0,0,0,1,              // rowId
                 11, 'b', 'l','o','b','C','o','l','u','m','n','1',
                 0,0,0,5, 1, 2, 3, 4 ,5      // blob
         };
 
         byte[] expected4 = {
+                6, 'q', 'u', 'e', 'r', 'y', '7', // queryId
                 0,0,0,1,              // rowId
                 11, 'b', 'l','o','b','C','o','l','u','m','n','2',
                 0,0,0,3, 6, 7, 8   // blob
@@ -353,21 +357,21 @@ public class BlobTest {
         Boolean firstFlag = booleanCaptor.getAllValues().get(0);
         byte[] actual = Arrays.copyOfRange(firstBuf.array(), firstBuf.position(), firstBuf.limit());
         assertArrayEquals(expected1, actual);
-        assertFalse(firstFlag);
+        assertTrue(firstFlag);
 
         // Verify second call
         ByteBuffer secondBuf = bufferCaptor.getAllValues().get(1);
         Boolean secondFlag = booleanCaptor.getAllValues().get(1);
         byte[] actualSecond = Arrays.copyOfRange(secondBuf.array(), secondBuf.position(), secondBuf.limit());
         assertArrayEquals(expected2, actualSecond);
-        assertFalse(secondFlag);
+        assertTrue(secondFlag);
 
         // Verify third call
         ByteBuffer thirdBuf = bufferCaptor.getAllValues().get(2);
         Boolean thirdFlag = booleanCaptor.getAllValues().get(2);
         byte[] actualThird = Arrays.copyOfRange(thirdBuf.array(), thirdBuf.position(), thirdBuf.limit());
         assertArrayEquals(expected3, actualThird);
-        assertFalse(thirdFlag);
+        assertTrue(thirdFlag);
 
         // Verify fourth call
         ByteBuffer fourthBuf = bufferCaptor.getAllValues().get(3);

--- a/src/test/java/BlobTest.java
+++ b/src/test/java/BlobTest.java
@@ -100,28 +100,28 @@ public class BlobTest {
         assertFalse(rs.next());
     }
 
+//    @Test
+//    public void testGetBinaryStreamByIndex() throws SQLException, IOException {
+//        // Prepare blob data
+//        byte[] blobData = {1, 2, 3, 4, 5};
+//
+//        // Use rowsByIndex to support getBinaryStream(int columnIndex)
+//        List<List<Object>> rowsByIndex = new ArrayList<>();
+//        rowsByIndex.add(Arrays.asList("Alice", new ByteArrayInputStream(blobData)));
+//
+//        MockResultSet rs = new MockResultSet(rowsByIndex);
+//
+//        assertTrue(rs.next(), "Should have first row");
+//
+//        InputStream is = rs.getBinaryStream(2); // second column
+//        assertNotNull(is, "BinaryStream should not be null");
+//
+//        byte[] readData = is.readAllBytes();
+//        assertArrayEquals(blobData, readData, "Binary data should match");
+//    }
+
     @Test
-    public void testGetBinaryStreamByIndex() throws SQLException, IOException {
-        // Prepare blob data
-        byte[] blobData = {1, 2, 3, 4, 5};
-
-        // Use rowsByIndex to support getBinaryStream(int columnIndex)
-        List<List<Object>> rowsByIndex = new ArrayList<>();
-        rowsByIndex.add(Arrays.asList("Alice", new ByteArrayInputStream(blobData)));
-
-        MockResultSet rs = new MockResultSet(rowsByIndex);
-
-        assertTrue(rs.next(), "Should have first row");
-
-        InputStream is = rs.getBinaryStream(2); // second column
-        assertNotNull(is, "BinaryStream should not be null");
-
-        byte[] readData = is.readAllBytes();
-        assertArrayEquals(blobData, readData, "Binary data should match");
-    }
-
-    @Test
-    public void testSendingSingleBlob() throws SQLException, IOException {
+    public void testSendingSingleRowWithBlob() throws SQLException, IOException {
         JsonObject obj = new JsonObject();
         obj.addProperty("id", "12345");
         BinarySender binarySender = mock(BinarySender.class);
@@ -157,7 +157,127 @@ public class BlobTest {
         byte[] actual = Arrays.copyOfRange(firstBuf.array(), firstBuf.position(), firstBuf.limit());
         assertArrayEquals(expectedResult, actual);
         assertTrue(firstFlag);
+    }
 
+    @Test
+    public void testSendingMultipleRowsWithBlobs() throws SQLException, IOException {
+        JsonObject obj = new JsonObject();
+        obj.addProperty("id", "12345");
+        BinarySender binarySender = mock(BinarySender.class);
+        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, binarySender, null, true);
+
+
+        BlockRetrievableRequestImpl block = new BlockRetrievableRequestImpl(io, null, obj);
+        byte[] blob1Data = {1, 2, 3, 4, 5};
+        byte[] blob2Data = {6, 7, 8};
+
+        byte[] expectedResult1 = {5, 49, 50, 51, 52, 53, 0, 4, 98, 108, 111, 98, 5, 1, 2, 3, 4, 5}; // queryIdLength | queryId | rowId | colNameLength | colName| bloblLength| blob
+        byte[] expectedResult2 = {1, 4, 98, 108, 111, 98, 3, 6, 7, 8}; //  rowId | colNameLength | colName| bloblLength| blob
+
+        Blob blob1 = new SerialBlob(blob1Data);
+        Blob blob2 = new SerialBlob(blob2Data);
+
+        // Use rowsByIndex to support getBinaryStream(int columnIndex)
+        List<List<Object>> rowsByIndex = new ArrayList<>();
+        rowsByIndex.add(Arrays.asList(blob1));
+        rowsByIndex.add(Arrays.asList(blob2));
+
+        Map<String, Object> row1 = new HashMap<>();
+        Map<String, Object> row2 = new HashMap<>();
+
+        row1.put("blob", blob1);
+        row2.put("blob", blob2);
+
+        List<Map<String, Object>> rows = Arrays.asList(row1, row2);
+        MockResultSet rs = new MockResultSet(rows, rowsByIndex);
+        block.getNextDataBlockUsage(rs, 2, false);
+
+        verify(binarySender, times(2)).send(any(ByteBuffer.class), anyBoolean());
+
+        // Assert - capture arguments
+        ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
+        ArgumentCaptor<Boolean> booleanCaptor = ArgumentCaptor.forClass(Boolean.class);
+
+        verify(binarySender, times(2)).send(bufferCaptor.capture(), booleanCaptor.capture());
+
+        // Verify first call
+        ByteBuffer firstBuf = bufferCaptor.getAllValues().get(0);
+        Boolean firstFlag = booleanCaptor.getAllValues().get(0);
+        byte[] actual = Arrays.copyOfRange(firstBuf.array(), firstBuf.position(), firstBuf.limit());
+        assertArrayEquals(expectedResult1, actual);
+        assertFalse(firstFlag);
+
+        // Verify second call
+        ByteBuffer secondBuf = bufferCaptor.getAllValues().get(1);
+        Boolean secondFlag = booleanCaptor.getAllValues().get(1);
+        byte[] actualSecond = Arrays.copyOfRange(secondBuf.array(), secondBuf.position(), secondBuf.limit());
+        assertArrayEquals(expectedResult2, actualSecond);
+        assertTrue(secondFlag);
+    }
+
+
+    @Test
+    public void testSingleRowMultipleBlobs() throws SQLException, IOException {
+        JsonObject obj = new JsonObject();
+        obj.addProperty("id", "123");
+        BinarySender binarySender = mock(BinarySender.class);
+        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, binarySender, null, true);
+
+
+        BlockRetrievableRequestImpl block = new BlockRetrievableRequestImpl(io, null, obj);
+        byte[] blobData1 = {10, 11};
+        byte[] blobData2 = {20, 21, 22};
+        Blob blob1 = new SerialBlob(blobData1);
+        Blob blob2 = new SerialBlob(blobData2);
+
+
+
+        byte[] expected1 = {
+                3, '1','2','3', // queryId
+                0,              // rowId
+                1, 'a',         // colName "a"
+                2, 10, 11,      // blob
+        };
+
+        byte[] expected2 = {
+                0,              // rowId
+                2, 'b','b',     // colName "bb"
+                3, 20, 21, 22   // blob
+        };
+        // Use rowsByIndex to support getBinaryStream(int columnIndex)
+        List<List<Object>> rowsByIndex = new ArrayList<>();
+        rowsByIndex.add(Arrays.asList(blob1, blob2));
+
+        Map<String, Object> row1 = new HashMap<>();
+
+        row1.put("a", blob1);
+        row1.put("bb", blob2);
+
+        List<Map<String, Object>> rows = Arrays.asList(row1);
+        MockResultSet rs = new MockResultSet(rows, rowsByIndex);
+        block.getNextDataBlockUsage(rs, 1, false);
+
+        verify(binarySender, times(2)).send(any(ByteBuffer.class), anyBoolean());
+
+        // Assert - capture arguments
+        ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
+        ArgumentCaptor<Boolean> booleanCaptor = ArgumentCaptor.forClass(Boolean.class);
+
+        verify(binarySender, times(2)).send(bufferCaptor.capture(), booleanCaptor.capture());
+
+        // Verify first call
+        ByteBuffer firstBuf = bufferCaptor.getAllValues().get(0);
+        Boolean firstFlag = booleanCaptor.getAllValues().get(0);
+        byte[] actual = Arrays.copyOfRange(firstBuf.array(), firstBuf.position(), firstBuf.limit());
+        assertArrayEquals(expected1, actual);
+        assertFalse(firstFlag);
+
+        // Verify second call
+        ByteBuffer secondBuf = bufferCaptor.getAllValues().get(1);
+        Boolean secondFlag = booleanCaptor.getAllValues().get(1);
+        byte[] actualSecond = Arrays.copyOfRange(secondBuf.array(), secondBuf.position(), secondBuf.limit());
+        assertArrayEquals(expected2, actualSecond);
+        assertTrue(secondFlag);
     }
 
 

--- a/src/test/java/BlobTest.java
+++ b/src/test/java/BlobTest.java
@@ -121,7 +121,7 @@ public class BlobTest {
     }
 
     @Test
-    public void testBlockRetrievableReq() throws SQLException, IOException {
+    public void testSendingSingleBlob() throws SQLException, IOException {
         JsonObject obj = new JsonObject();
         obj.addProperty("id", "12345");
         BinarySender binarySender = mock(BinarySender.class);
@@ -130,7 +130,7 @@ public class BlobTest {
 
         BlockRetrievableRequestImpl block = new BlockRetrievableRequestImpl(io, null, obj);
         byte[] blobData = {1, 2, 3, 4, 5};
-        byte[] expectedResult = {5, 49, 50, 51, 52, 53, 4, 98, 108, 111, 98, 1, 2, 3, 4, 5};
+        byte[] expectedResult = {5, 49, 50, 51, 52, 53, 0, 4, 98, 108, 111, 98, 5, 1, 2, 3, 4, 5}; // queryIdLength | queryId | rowId | colNameLength | colName| bloblLength| blob
         Blob blob = new SerialBlob(blobData);
 
         // Use rowsByIndex to support getBinaryStream(int columnIndex)

--- a/src/test/java/BlobTest.java
+++ b/src/test/java/BlobTest.java
@@ -1,6 +1,7 @@
 import com.github.ibm.mapepire.DataStreamProcessor;
 import com.github.ibm.mapepire.requests.BlockRetrievableRequest;
-import com.github.ibm.mapepire.ws.BinarySender;
+import com.github.ibm.mapepire.ws.AsyncSender;
+//import com.github.ibm.mapepire.ws.asyncSender;
 import com.google.gson.JsonObject;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -124,8 +125,8 @@ public class BlobTest {
     public void testSendingSingleRowWithBlob() throws SQLException, IOException {
         JsonObject obj = new JsonObject();
         obj.addProperty("id", "12345");
-        BinarySender binarySender = mock(BinarySender.class);
-        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, binarySender, null, true);
+        AsyncSender asyncSender = mock(AsyncSender.class);
+        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, asyncSender, null, true);
 
 
         BlockRetrievableRequestImpl block = new BlockRetrievableRequestImpl(io, null, obj);
@@ -143,13 +144,13 @@ public class BlobTest {
         MockResultSet rs = new MockResultSet(rows, rowsByIndex);
         block.getNextDataBlockUsage(rs, 1, false);
 
-        verify(binarySender, times(1)).send(any(ByteBuffer.class), anyBoolean());
+        verify(asyncSender, times(1)).send(any(ByteBuffer.class), anyBoolean());
 
         // Assert - capture arguments
         ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
         ArgumentCaptor<Boolean> booleanCaptor = ArgumentCaptor.forClass(Boolean.class);
 
-        verify(binarySender, times(1)).send(bufferCaptor.capture(), booleanCaptor.capture());
+        verify(asyncSender, times(1)).send(bufferCaptor.capture(), booleanCaptor.capture());
 
         // Verify first call
         ByteBuffer firstBuf = bufferCaptor.getAllValues().get(0);
@@ -163,8 +164,8 @@ public class BlobTest {
     public void testSendingMultipleRowsWithBlobs() throws SQLException, IOException {
         JsonObject obj = new JsonObject();
         obj.addProperty("id", "12345");
-        BinarySender binarySender = mock(BinarySender.class);
-        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, binarySender, null, true);
+        AsyncSender asyncSender = mock(AsyncSender.class);
+        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, asyncSender, null, true);
 
 
         BlockRetrievableRequestImpl block = new BlockRetrievableRequestImpl(io, null, obj);
@@ -192,13 +193,13 @@ public class BlobTest {
         MockResultSet rs = new MockResultSet(rows, rowsByIndex);
         block.getNextDataBlockUsage(rs, 2, false);
 
-        verify(binarySender, times(2)).send(any(ByteBuffer.class), anyBoolean());
+        verify(asyncSender, times(2)).send(any(ByteBuffer.class), anyBoolean());
 
         // Assert - capture arguments
         ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
         ArgumentCaptor<Boolean> booleanCaptor = ArgumentCaptor.forClass(Boolean.class);
 
-        verify(binarySender, times(2)).send(bufferCaptor.capture(), booleanCaptor.capture());
+        verify(asyncSender, times(2)).send(bufferCaptor.capture(), booleanCaptor.capture());
 
         // Verify first call
         ByteBuffer firstBuf = bufferCaptor.getAllValues().get(0);
@@ -220,8 +221,8 @@ public class BlobTest {
     public void testSingleRowMultipleBlobs() throws SQLException, IOException {
         JsonObject obj = new JsonObject();
         obj.addProperty("id", "123");
-        BinarySender binarySender = mock(BinarySender.class);
-        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, binarySender, null, true);
+        AsyncSender asyncSender = mock(AsyncSender.class);
+        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, asyncSender, null, true);
 
 
         BlockRetrievableRequestImpl block = new BlockRetrievableRequestImpl(io, null, obj);
@@ -258,13 +259,13 @@ public class BlobTest {
         MockResultSet rs = new MockResultSet(rows, rowsByIndex);
         block.getNextDataBlockUsage(rs, 1, false);
 
-        verify(binarySender, times(2)).send(any(ByteBuffer.class), anyBoolean());
+        verify(asyncSender, times(2)).send(any(ByteBuffer.class), anyBoolean());
 
         // Assert - capture arguments
         ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
         ArgumentCaptor<Boolean> booleanCaptor = ArgumentCaptor.forClass(Boolean.class);
 
-        verify(binarySender, times(2)).send(bufferCaptor.capture(), booleanCaptor.capture());
+        verify(asyncSender, times(2)).send(bufferCaptor.capture(), booleanCaptor.capture());
 
         // Verify first call
         ByteBuffer firstBuf = bufferCaptor.getAllValues().get(0);
@@ -285,8 +286,8 @@ public class BlobTest {
     public void testMultipleRowsMultipleBlobsPerRow() throws SQLException, IOException {
         JsonObject obj = new JsonObject();
         obj.addProperty("id", "query7");
-        BinarySender binarySender = mock(BinarySender.class);
-        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, binarySender, null, true);
+        AsyncSender asyncSender = mock(AsyncSender.class);
+        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, asyncSender, null, true);
 
 
         BlockRetrievableRequestImpl block = new BlockRetrievableRequestImpl(io, null, obj);
@@ -344,13 +345,13 @@ public class BlobTest {
         MockResultSet rs = new MockResultSet(rows, rowsByIndex);
         block.getNextDataBlockUsage(rs, 2, false);
 
-        verify(binarySender, times(4)).send(any(ByteBuffer.class), anyBoolean());
+        verify(asyncSender, times(4)).send(any(ByteBuffer.class), anyBoolean());
 
         // Assert - capture arguments
         ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
         ArgumentCaptor<Boolean> booleanCaptor = ArgumentCaptor.forClass(Boolean.class);
 
-        verify(binarySender, times(4)).send(bufferCaptor.capture(), booleanCaptor.capture());
+        verify(asyncSender, times(4)).send(bufferCaptor.capture(), booleanCaptor.capture());
 
         // Verify first call
         ByteBuffer firstBuf = bufferCaptor.getAllValues().get(0);
@@ -386,8 +387,8 @@ public class BlobTest {
     public void testSendingSingleRowWithEmptyBlob() throws SQLException, IOException {
         JsonObject obj = new JsonObject();
         obj.addProperty("id", "12345");
-        BinarySender binarySender = mock(BinarySender.class);
-        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, binarySender, null, true);
+        AsyncSender asyncSender = mock(AsyncSender.class);
+        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, asyncSender, null, true);
 
 
         BlockRetrievableRequestImpl block = new BlockRetrievableRequestImpl(io, null, obj);
@@ -404,13 +405,13 @@ public class BlobTest {
         MockResultSet rs = new MockResultSet(rows, rowsByIndex);
         block.getNextDataBlockUsage(rs, 1, false);
 
-        verify(binarySender, times(0)).send(any(ByteBuffer.class), anyBoolean());
+        verify(asyncSender, times(0)).send(any(ByteBuffer.class), anyBoolean());
 
         // Assert - capture arguments
         ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
         ArgumentCaptor<Boolean> booleanCaptor = ArgumentCaptor.forClass(Boolean.class);
 
-        verify(binarySender, times(0)).send(bufferCaptor.capture(), booleanCaptor.capture());
+        verify(asyncSender, times(0)).send(bufferCaptor.capture(), booleanCaptor.capture());
 
     }
 
@@ -418,8 +419,8 @@ public class BlobTest {
     public void testSendingSingleRowWithBlobandNonblobColumns() throws SQLException, IOException {
         JsonObject obj = new JsonObject();
         obj.addProperty("id", "12345");
-        BinarySender binarySender = mock(BinarySender.class);
-        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, binarySender, null, true);
+        AsyncSender asyncSender = mock(AsyncSender.class);
+        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, asyncSender, null, true);
 
 
         BlockRetrievableRequestImpl block = new BlockRetrievableRequestImpl(io, null, obj);
@@ -441,13 +442,13 @@ public class BlobTest {
         MockResultSet rs = new MockResultSet(rows, rowsByIndex);
         block.getNextDataBlockUsage(rs, 1, false);
 
-        verify(binarySender, times(1)).send(any(ByteBuffer.class), anyBoolean());
+        verify(asyncSender, times(1)).send(any(ByteBuffer.class), anyBoolean());
 
         // Assert - capture arguments
         ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
         ArgumentCaptor<Boolean> booleanCaptor = ArgumentCaptor.forClass(Boolean.class);
 
-        verify(binarySender, times(1)).send(bufferCaptor.capture(), booleanCaptor.capture());
+        verify(asyncSender, times(1)).send(bufferCaptor.capture(), booleanCaptor.capture());
 
         // Verify first call
         ByteBuffer firstBuf = bufferCaptor.getAllValues().get(0);
@@ -462,8 +463,8 @@ public class BlobTest {
     public void testSendingSingleRowWithLongBlob() throws SQLException, IOException {
         JsonObject obj = new JsonObject();
         obj.addProperty("id", "12345");
-        BinarySender binarySender = mock(BinarySender.class);
-        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, binarySender, null, true);
+        AsyncSender asyncSender = mock(AsyncSender.class);
+        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, asyncSender, null, true);
 
 
         BlockRetrievableRequestImpl block = new BlockRetrievableRequestImpl(io, null, obj);
@@ -498,13 +499,13 @@ public class BlobTest {
         List<Map<String, Object>> rows = Arrays.asList(row1);
         MockResultSet rs = new MockResultSet(rows, rowsByIndex);
 //
-//        verify(binarySender, times(641)).send(any(ByteBuffer.class), anyBoolean());
+//        verify(asyncSender, times(641)).send(any(ByteBuffer.class), anyBoolean());
 //
 //        // Assert - capture arguments
 //        ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
 //        ArgumentCaptor<Boolean> booleanCaptor = ArgumentCaptor.forClass(Boolean.class);
 //
-//        verify(binarySender, times(641)).send(bufferCaptor.capture(), booleanCaptor.capture());
+//        verify(asyncSender, times(641)).send(bufferCaptor.capture(), booleanCaptor.capture());
 //
 //        // Verify first call
 //        ByteBuffer firstBuf = bufferCaptor.getAllValues().get(0);
@@ -526,7 +527,7 @@ public class BlobTest {
             capturedFlags.add(isFinal);
 
             return null;
-        }).when(binarySender).send(any(ByteBuffer.class), anyBoolean());
+        }).when(asyncSender).send(any(ByteBuffer.class), anyBoolean());
         block.getNextDataBlockUsage(rs, 1, false);
 
         byte[] actualFirst21 = Arrays.copyOfRange(capturedBuffers.get(0), 0, 25);

--- a/src/test/java/BlobTest.java
+++ b/src/test/java/BlobTest.java
@@ -1,0 +1,164 @@
+import com.github.ibm.mapepire.DataStreamProcessor;
+import com.github.ibm.mapepire.requests.BlockRetrievableRequest;
+import com.github.ibm.mapepire.ws.BinarySender;
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+import javax.sql.rowset.serial.SerialBlob;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.sql.Blob;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+public class BlobTest {
+
+    @Test
+    public void testMockResultSetSingleRow() throws SQLException {
+        // Arrange
+        Map<String, Object> row = new HashMap<>();
+        List<List<Object>> rowsByIndex;
+
+        row.put("id", 1);
+        row.put("name", "Alice");
+
+        List<Map<String, Object>> rows = Collections.singletonList(row);
+        ResultSet rs = new MockResultSet(rows, null);
+
+        // Act & Assert
+        assertTrue(rs.next(), "Expected at least one row");
+        assertEquals(1, rs.getInt("id"));
+        assertEquals("Alice", rs.getString("name"));
+
+        assertFalse(rs.next(), "No more rows expected");
+    }
+
+    @Test
+    public void testMockResultSetMultipleRows() throws SQLException {
+        // Arrange
+        Map<String, Object> row1 = new HashMap<>();
+        row1.put("id", 1);
+        row1.put("name", "Alice");
+
+        Map<String, Object> row2 = new HashMap<>();
+        row2.put("id", 2);
+        row2.put("name", "Bob");
+
+        List<Map<String, Object>> rows = Arrays.asList(row1, row2);
+        ResultSet rs = new MockResultSet(rows, null);
+
+        // First row
+        assertTrue(rs.next());
+        assertEquals(1, rs.getInt("id"));
+        assertEquals("Alice", rs.getString("name"));
+
+        // Second row
+        assertTrue(rs.next());
+        assertEquals(2, rs.getInt("id"));
+        assertEquals("Bob", rs.getString("name"));
+
+        // No more
+        assertFalse(rs.next());
+    }
+
+    @Test
+    void testBlobColumnInResultSet() throws Exception {
+        // Create some fake binary data
+        byte[] data = "hello world".getBytes();
+
+        // Wrap it in a Blob
+        Blob blob = new SerialBlob(data);
+
+        List<List<Object>> rowsByIndex = Arrays.asList(Arrays.asList(blob));
+
+
+        // Use MockResultSet to simulate a DB result
+        MockResultSet rs = new MockResultSet(rowsByIndex);
+
+        // Act: move to the first row
+        assertTrue(rs.next());
+
+        // Retrieve the blob
+        Blob retrievedBlob = rs.getBlob(1);
+        assertNotNull(retrievedBlob);
+
+        // Read the bytes back
+        byte[] retrievedData = retrievedBlob.getBytes(1, (int) retrievedBlob.length());
+
+        // Verify the round-trip matches
+        assertArrayEquals(data, retrievedData);
+
+        // No more rows
+        assertFalse(rs.next());
+    }
+
+    @Test
+    public void testGetBinaryStreamByIndex() throws SQLException, IOException {
+        // Prepare blob data
+        byte[] blobData = {1, 2, 3, 4, 5};
+
+        // Use rowsByIndex to support getBinaryStream(int columnIndex)
+        List<List<Object>> rowsByIndex = new ArrayList<>();
+        rowsByIndex.add(Arrays.asList("Alice", new ByteArrayInputStream(blobData)));
+
+        MockResultSet rs = new MockResultSet(rowsByIndex);
+
+        assertTrue(rs.next(), "Should have first row");
+
+        InputStream is = rs.getBinaryStream(2); // second column
+        assertNotNull(is, "BinaryStream should not be null");
+
+        byte[] readData = is.readAllBytes();
+        assertArrayEquals(blobData, readData, "Binary data should match");
+    }
+
+    @Test
+    public void testBlockRetrievableReq() throws SQLException, IOException {
+        JsonObject obj = new JsonObject();
+        obj.addProperty("id", "12345");
+        BinarySender binarySender = mock(BinarySender.class);
+        final DataStreamProcessor io = new DataStreamProcessor(System.in, System.out, binarySender, null, true);
+
+
+        BlockRetrievableRequestImpl block = new BlockRetrievableRequestImpl(io, null, obj);
+        byte[] blobData = {1, 2, 3, 4, 5};
+        byte[] expectedResult = {5, 49, 50, 51, 52, 53, 4, 98, 108, 111, 98, 1, 2, 3, 4, 5};
+        Blob blob = new SerialBlob(blobData);
+
+        // Use rowsByIndex to support getBinaryStream(int columnIndex)
+        List<List<Object>> rowsByIndex = new ArrayList<>();
+        rowsByIndex.add(Arrays.asList(blob));
+
+        Map<String, Object> row1 = new HashMap<>();
+        row1.put("blob", blob);
+        List<Map<String, Object>> rows = Arrays.asList(row1);
+        MockResultSet rs = new MockResultSet(rows, rowsByIndex);
+        block.getNextDataBlockUsage(rs, 1, false);
+
+        verify(binarySender, times(1)).send(any(ByteBuffer.class), anyBoolean());
+
+        // Assert - capture arguments
+        ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
+        ArgumentCaptor<Boolean> booleanCaptor = ArgumentCaptor.forClass(Boolean.class);
+
+        verify(binarySender, times(1)).send(bufferCaptor.capture(), booleanCaptor.capture());
+
+        // Verify first call
+        ByteBuffer firstBuf = bufferCaptor.getAllValues().get(0);
+        Boolean firstFlag = booleanCaptor.getAllValues().get(0);
+        byte[] actual = Arrays.copyOfRange(firstBuf.array(), firstBuf.position(), firstBuf.limit());
+        assertArrayEquals(expectedResult, actual);
+        assertTrue(firstFlag);
+
+    }
+
+
+}

--- a/src/test/java/BlockRetrievableRequestImpl.java
+++ b/src/test/java/BlockRetrievableRequestImpl.java
@@ -1,0 +1,22 @@
+import com.github.ibm.mapepire.DataStreamProcessor;
+import com.github.ibm.mapepire.SystemConnection;
+import com.github.ibm.mapepire.requests.BlockRetrievableRequest;
+import com.google.gson.JsonObject;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class BlockRetrievableRequestImpl extends BlockRetrievableRequest {
+    protected BlockRetrievableRequestImpl(DataStreamProcessor _io, SystemConnection _conn, JsonObject _reqObj) {
+        super(_io, _conn, _reqObj);
+    }
+
+    public DataBlockFetchResult getNextDataBlockUsage(final ResultSet _rs, final int _numRows,
+                     final boolean _isTerseDataFormat) throws SQLException, IOException {
+        return getNextDataBlock(_rs, _numRows, _isTerseDataFormat);
+    }
+    @Override
+    protected void go() throws Exception {
+    }
+}

--- a/src/test/java/MockResultSet.java
+++ b/src/test/java/MockResultSet.java
@@ -1030,6 +1030,4 @@ public class MockResultSet implements ResultSet {
         return false;
     }
 
-
-    // Add more getters as needed...
 }

--- a/src/test/java/MockResultSet.java
+++ b/src/test/java/MockResultSet.java
@@ -26,6 +26,9 @@ public class MockResultSet implements ResultSet {
     public ResultSetMetaData getMetaData() throws SQLException {
         return new ResultSetMetaData() {
             private final List<String> columns = new ArrayList<>(rows.get(0).keySet());
+            { // instance initializer
+                Collections.sort(columns);
+            }
 
             @Override
             public int getColumnCount() throws SQLException {

--- a/src/test/java/MockResultSet.java
+++ b/src/test/java/MockResultSet.java
@@ -1,0 +1,1032 @@
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.*;
+import java.sql.Date;
+import java.util.*;
+
+public class MockResultSet implements ResultSet {
+    private List<Map<String, Object>> rows = null;
+    private List<List<Object>> rowsByIndex = null;
+
+    private int cursor = -1;
+
+    public MockResultSet(List<Map<String, Object>> rows, List<List<Object>> rowsByIndex) {
+        this.rows = rows;
+        this.rowsByIndex = rowsByIndex;
+    }
+
+
+    public MockResultSet( List<List<Object>> rowsByIndex) {
+        this.rowsByIndex = rowsByIndex;
+    }
+
+    @Override
+    public ResultSetMetaData getMetaData() throws SQLException {
+        return new ResultSetMetaData() {
+            private final List<String> columns = new ArrayList<>(rows.get(0).keySet());
+
+            @Override
+            public int getColumnCount() throws SQLException {
+                return columns.size();
+            }
+
+            @Override
+            public String getColumnName(int column) throws SQLException {
+                // JDBC columns are 1-based
+                return columns.get(column - 1);
+            }
+
+            @Override
+            public int getColumnType(int column) throws SQLException {
+                Object value = rows.get(0).get(getColumnName(column));
+                if (value instanceof String) return Types.VARCHAR;
+                if (value instanceof Integer) return Types.INTEGER;
+                if (value instanceof byte[]) return Types.BLOB;
+                // add more types as needed
+                return Types.OTHER;
+            }
+
+            // Implement other methods as needed
+            @Override public boolean isAutoIncrement(int column) { return false; }
+            @Override public boolean isCaseSensitive(int column) { return true; }
+            @Override public boolean isSearchable(int column) { return true; }
+            @Override public boolean isCurrency(int column) { return false; }
+            @Override public int isNullable(int column) { return ResultSetMetaData.columnNullable; }
+            @Override public boolean isSigned(int column) { return true; }
+            @Override public int getColumnDisplaySize(int column) { return 255; }
+            @Override public String getColumnLabel(int column) throws SQLException { return getColumnName(column); }
+            @Override public String getSchemaName(int column) { return ""; }
+            @Override public int getPrecision(int column) { return 0; }
+            @Override public int getScale(int column) { return 0; }
+            @Override public String getTableName(int column) { return ""; }
+            @Override public String getCatalogName(int column) { return ""; }
+            @Override public String getColumnTypeName(int column) throws SQLException { return getColumnName(column); }
+            @Override public boolean isReadOnly(int column) { return true; }
+            @Override public boolean isWritable(int column) { return false; }
+            @Override public boolean isDefinitelyWritable(int column) { return false; }
+            @Override public String getColumnClassName(int column) { return Object.class.getName(); }
+            @Override public <T> T unwrap(Class<T> iface) { return null; }
+            @Override public boolean isWrapperFor(Class<?> iface) { return false; }
+        };
+    }
+
+    @Override
+    public boolean next() throws SQLException {
+        if ((rows != null && cursor + 1 < rows.size()) || (rowsByIndex != null && cursor + 1 < rowsByIndex.size())) {
+            cursor++;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void close() throws SQLException {
+
+    }
+
+    @Override
+    public boolean wasNull() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public String getString(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean getBoolean(int columnIndex) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public byte getByte(int columnIndex) throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public short getShort(int columnIndex) throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getInt(int columnIndex) throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public long getLong(int columnIndex) throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public float getFloat(int columnIndex) throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public double getDouble(int columnIndex) throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public byte[] getBytes(int columnIndex) throws SQLException {
+        return new byte[0];
+    }
+
+    @Override
+    public Date getDate(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Time getTime(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Timestamp getTimestamp(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public InputStream getAsciiStream(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public InputStream getUnicodeStream(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public InputStream getBinaryStream(int columnIndex) throws SQLException {
+        return ((Blob) rowsByIndex.get(cursor).get(columnIndex - 1)).getBinaryStream();
+    }
+
+    @Override
+    public String getString(String columnLabel) throws SQLException {
+        return (String) rows.get(cursor).get(columnLabel);
+    }
+
+    @Override
+    public boolean getBoolean(String columnLabel) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public byte getByte(String columnLabel) throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public short getShort(String columnLabel) throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getInt(String columnLabel) throws SQLException {
+        return (Integer) rows.get(cursor).get(columnLabel);
+    }
+
+    @Override
+    public long getLong(String columnLabel) throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public float getFloat(String columnLabel) throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public double getDouble(String columnLabel) throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public byte[] getBytes(String columnLabel) throws SQLException {
+        return new byte[0];
+    }
+
+    @Override
+    public Date getDate(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Time getTime(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Timestamp getTimestamp(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public InputStream getAsciiStream(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public InputStream getUnicodeStream(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public InputStream getBinaryStream(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public void clearWarnings() throws SQLException {
+
+    }
+
+    @Override
+    public String getCursorName() throws SQLException {
+        return null;
+    }
+
+
+    @Override
+    public Object getObject(int columnIndex) throws SQLException {
+        return rowsByIndex.get(cursor).get(columnIndex - 1);
+    }
+
+    @Override
+    public Object getObject(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public int findColumn(String columnLabel) throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public Reader getCharacterStream(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Reader getCharacterStream(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean isBeforeFirst() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean isAfterLast() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean isFirst() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean isLast() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public void beforeFirst() throws SQLException {
+
+    }
+
+    @Override
+    public void afterLast() throws SQLException {
+
+    }
+
+    @Override
+    public boolean first() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean last() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public int getRow() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public boolean absolute(int row) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean relative(int rows) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean previous() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public void setFetchDirection(int direction) throws SQLException {
+
+    }
+
+    @Override
+    public int getFetchDirection() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public void setFetchSize(int rows) throws SQLException {
+
+    }
+
+    @Override
+    public int getFetchSize() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getType() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public int getConcurrency() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public boolean rowUpdated() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean rowInserted() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean rowDeleted() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public void updateNull(int columnIndex) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBoolean(int columnIndex, boolean x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateByte(int columnIndex, byte x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateShort(int columnIndex, short x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateInt(int columnIndex, int x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateLong(int columnIndex, long x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateFloat(int columnIndex, float x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateDouble(int columnIndex, double x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateString(int columnIndex, String x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBytes(int columnIndex, byte[] x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateDate(int columnIndex, Date x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateTime(int columnIndex, Time x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException {
+
+    }
+
+    @Override
+    public void updateObject(int columnIndex, Object x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateNull(String columnLabel) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBoolean(String columnLabel, boolean x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateByte(String columnLabel, byte x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateShort(String columnLabel, short x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateInt(String columnLabel, int x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateLong(String columnLabel, long x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateFloat(String columnLabel, float x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateDouble(String columnLabel, double x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateString(String columnLabel, String x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBytes(String columnLabel, byte[] x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateDate(String columnLabel, Date x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateTime(String columnLabel, Time x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateAsciiStream(String columnLabel, InputStream x, int length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBinaryStream(String columnLabel, InputStream x, int length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateCharacterStream(String columnLabel, Reader reader, int length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException {
+
+    }
+
+    @Override
+    public void updateObject(String columnLabel, Object x) throws SQLException {
+
+    }
+
+    @Override
+    public void insertRow() throws SQLException {
+
+    }
+
+    @Override
+    public void updateRow() throws SQLException {
+
+    }
+
+    @Override
+    public void deleteRow() throws SQLException {
+
+    }
+
+    @Override
+    public void refreshRow() throws SQLException {
+
+    }
+
+    @Override
+    public void cancelRowUpdates() throws SQLException {
+
+    }
+
+    @Override
+    public void moveToInsertRow() throws SQLException {
+
+    }
+
+    @Override
+    public void moveToCurrentRow() throws SQLException {
+
+    }
+
+    @Override
+    public Statement getStatement() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Ref getRef(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Blob getBlob(int columnIndex) throws SQLException {
+        return (Blob) rowsByIndex.get(cursor).get(columnIndex - 1);
+    }
+
+    @Override
+    public Clob getClob(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Array getArray(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Ref getRef(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Blob getBlob(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Clob getClob(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Array getArray(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Date getDate(int columnIndex, Calendar cal) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Date getDate(String columnLabel, Calendar cal) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Time getTime(String columnLabel, Calendar cal) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public URL getURL(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public URL getURL(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public void updateRef(int columnIndex, Ref x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateRef(String columnLabel, Ref x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBlob(int columnIndex, Blob x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBlob(String columnLabel, Blob x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateClob(int columnIndex, Clob x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateClob(String columnLabel, Clob x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateArray(int columnIndex, Array x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateArray(String columnLabel, Array x) throws SQLException {
+
+    }
+
+    @Override
+    public RowId getRowId(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public RowId getRowId(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public void updateRowId(int columnIndex, RowId x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateRowId(String columnLabel, RowId x) throws SQLException {
+
+    }
+
+    @Override
+    public int getHoldability() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public boolean isClosed() throws SQLException {
+        return false;
+    }
+
+    @Override
+    public void updateNString(int columnIndex, String nString) throws SQLException {
+
+    }
+
+    @Override
+    public void updateNString(String columnLabel, String nString) throws SQLException {
+
+    }
+
+    @Override
+    public void updateNClob(int columnIndex, NClob nClob) throws SQLException {
+
+    }
+
+    @Override
+    public void updateNClob(String columnLabel, NClob nClob) throws SQLException {
+
+    }
+
+    @Override
+    public NClob getNClob(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public NClob getNClob(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public SQLXML getSQLXML(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public SQLXML getSQLXML(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException {
+
+    }
+
+    @Override
+    public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException {
+
+    }
+
+    @Override
+    public String getNString(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public String getNString(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Reader getNCharacterStream(int columnIndex) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public Reader getNCharacterStream(String columnLabel) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateNCharacterStream(String columnLabel, Reader reader, long length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateAsciiStream(String columnLabel, InputStream x, long length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBinaryStream(String columnLabel, InputStream x, long length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateCharacterStream(String columnLabel, Reader reader, long length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBlob(int columnIndex, InputStream inputStream, long length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBlob(String columnLabel, InputStream inputStream, long length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateClob(int columnIndex, Reader reader, long length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateClob(String columnLabel, Reader reader, long length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException {
+
+    }
+
+    @Override
+    public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException {
+
+    }
+
+    @Override
+    public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateCharacterStream(int columnIndex, Reader x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException {
+
+    }
+
+    @Override
+    public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException {
+
+    }
+
+    @Override
+    public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException {
+
+    }
+
+    @Override
+    public void updateClob(int columnIndex, Reader reader) throws SQLException {
+
+    }
+
+    @Override
+    public void updateClob(String columnLabel, Reader reader) throws SQLException {
+
+    }
+
+    @Override
+    public void updateNClob(int columnIndex, Reader reader) throws SQLException {
+
+    }
+
+    @Override
+    public void updateNClob(String columnLabel, Reader reader) throws SQLException {
+
+    }
+
+    @Override
+    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return false;
+    }
+
+
+    // Add more getters as needed...
+}


### PR DESCRIPTION
Binary data received in form
|blobQueryId (2 bytes)| replacementIndex (1 byte) | blobLength (4 bytes) | blob (blobLength bytes)| replacementIndex (1 byte) | blobLength (4 bytes) | blob (blobLength bytes)| ...

binary data sent in form
|queryIdLength (1 byte) | queryId (queryIdLength bytes) (utf8) | rowId (4 bytes) | colNameLength (1 byte) | colName (colNameLength bytes) (utf8) | blobLength (4 bytes) | blob (blobLength bytes)|

The changes for the js client are here [https://github.com/Mapepire-IBMi/mapepire-js/pull/55](https://github.com/Mapepire-IBMi/mapepire-js/pull/55)

We will need similar changes for the other clients. 

Note: We shouldn't merge this before getting the other clients ready because it does have breaking changes. Namely there is a rowId field that is sent back in blob requests that is used as metadata. The field needs to be deleted once the full response is assebled on the client side.