### PR TITLE
Added table name in column metadata

### DIFF
--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -172,6 +172,7 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
             columnAttrs.put("nullable", _md.isNullable(i));
             columnAttrs.put("readOnly", _md.isReadOnly(i));
             columnAttrs.put("writeable", _md.isWritable(i));
+            columnAttrs.put("table", _md.getTableName(i));
             columnMetaData.add(columnAttrs);
         }
         metaData.put("columns", columnMetaData);

--- a/src/main/java/com/github/ibm/mapepire/requests/PrepareSql.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/PrepareSql.java
@@ -49,6 +49,13 @@ public class PrepareSql extends BlockRetrievableRequest {
                 columnAttrs.put("type", rsMetaData.getColumnTypeName(i));
                 columnAttrs.put("display_size", rsMetaData.getColumnDisplaySize(i));
                 columnAttrs.put("label", rsMetaData.getColumnLabel(i));
+	            columnAttrs.put("precision", rsMetaData.getPrecision(i));
+	            columnAttrs.put("scale", rsMetaData.getScale(i));
+	            columnAttrs.put("autoIncrement", rsMetaData.isAutoIncrement(i));
+	            columnAttrs.put("nullable", rsMetaData.isNullable(i));
+	            columnAttrs.put("readOnly", rsMetaData.isReadOnly(i));
+	            columnAttrs.put("writeable", rsMetaData.isWritable(i));
+	            columnAttrs.put("table", rsMetaData.getTableName(i));
                 columnMetaData.add(columnAttrs);
             }
             metaData.put("columns", columnMetaData);


### PR DESCRIPTION
This PR adds a `table` attribute to the column metadata.
This will help discriminate columns with the same name from multiple tables.

It also adds the additional metadata added by https://github.com/Mapepire-IBMi/mapepire-server/pull/122 to the PrepareSQL request.