### PR TITLE
Fix/translate binaray

### DIFF
--- a/src/main/java/com/github/ibm/mapepire/Version.java
+++ b/src/main/java/com/github/ibm/mapepire/Version.java
@@ -1,5 +1,5 @@
 package com.github.ibm.mapepire;
 public class Version {
-      static public final String s_compileDateTime = "2026-02-11 18:29:32 (GMT)";
-      static public final String s_version = "2.3.4";
+      static public final String s_compileDateTime = "2024-08-08 00:36:20 (GMT)";
+      static public final String s_version = "2.0.0-rc1";
 }

--- a/src/main/java/com/github/ibm/mapepire/Version.java
+++ b/src/main/java/com/github/ibm/mapepire/Version.java
@@ -1,5 +1,5 @@
 package com.github.ibm.mapepire;
 public class Version {
-      static public final String s_compileDateTime = "2024-08-08 00:36:20 (GMT)";
-      static public final String s_version = "2.0.0-rc1";
+      static public final String s_compileDateTime = "2026-02-11 18:29:32 (GMT)";
+      static public final String s_version = "2.3.4";
 }

--- a/src/main/java/com/github/ibm/mapepire/requests/DoVe.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/DoVe.java
@@ -129,7 +129,7 @@ public class DoVe extends BlockRetrievableRequest {
         try (Statement dbMonStmt = jdbcConn.createStatement()) {
             dbMonStmt.execute("drop table QTEMP.QDOVEOUT");
         } catch (Exception e) {
-            Tracer.info(e.getMessage());
+            Tracer.info(e.getMessage()); 
         }
     }
 }

--- a/src/main/java/com/github/ibm/mapepire/requests/DoVe.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/DoVe.java
@@ -8,6 +8,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
+import java.sql.ParameterMetaData;
 import com.github.ibm.mapepire.DataStreamProcessor;
 import com.github.ibm.mapepire.SystemConnection;
 import com.github.ibm.mapepire.Tracer;
@@ -30,7 +31,8 @@ public class DoVe extends BlockRetrievableRequest {
         final Connection jdbcConn = getSystemConnection().getJdbcConnection();
         boolean isRunning = getRequestFieldBoolean("run", false);
         final int numRows = super.getRequestFieldInt("rows", 1000);
-        byte[] id = new byte[0];
+        byte[] idBytes = null;
+        String idStr = null;
 
         try (Statement dbMonStmt = jdbcConn.createStatement();
                 Statement qaqqiniStmt = jdbcConn.createStatement()) {
@@ -40,7 +42,6 @@ public class DoVe extends BlockRetrievableRequest {
                 if (!isRunning) {
                     qaqqiniStmt.execute("CALL QSYS2.OVERRIDE_QAQQINI(2, 'QUERY_TIME_LIMIT', '0')");
                 }
-                //qaqqiniStmt.execute("CALL QSYS2.OVERRIDE_QAQQINI(2, 'SQL_STMT_REUSE','255')");
                 qaqqiniStmt.execute("CALL QSYS2.OVERRIDE_QAQQINI(2, 'OPEN_CURSOR_CLOSE_COUNT','65535')");
                 qaqqiniStmt.execute("CALL QSYS2.OVERRIDE_QAQQINI(2, 'OPEN_CURSOR_THRESHOLD','-1')");
                 PreparedStatement tgt = jdbcConn.prepareStatement(sql);
@@ -68,14 +69,44 @@ public class DoVe extends BlockRetrievableRequest {
             }
             try (ResultSet rs = dbMonStmt.executeQuery("SELECT QQJFLD FROM QTEMP.QDOVEOUT WHERE QQRID = 3014 lImIt 1")) {
                 if (rs.next()) {
-                    id = rs.getBytes(1);
+                    // Capture both forms because QQQDBVE param 1 may be VARCHAR or BINARY depending on driver settings
+                    // (especially affected by translate-binary setting)
+                    idStr = rs.getString(1);
+                    idBytes = rs.getBytes(1);
                 }
             }
         }
 
+        // Validate that we successfully retrieved the QQQDBVE identifier before proceeding
+        if (idStr == null && idBytes == null) {
+            throw new RuntimeException("Unable to locate QQQDBVE id in QTEMP.QDOVEOUT (QQRID=3014)");
+        }
+
         try (CallableStatement callStmt = jdbcConn.prepareCall(
                 "call QSYS.QQQDBVE(?,?,?,?)")) {
-            callStmt.setBytes(1, id);
+            // FIX: Detect the actual parameter type before binding to avoid "Data type mismatch" error.
+            // The jt400 driver may describe QQQDBVE param 1 as VARCHAR or BINARY depending on
+            // translate-binary and other settings. Previously we always used setBytes(), which fails
+            // when the driver expects a character type. Now we check metadata and bind appropriately.
+            ParameterMetaData pmd = callStmt.getParameterMetaData();
+            int p1Type = Types.OTHER;
+            try {
+                p1Type = pmd.getParameterType(1);
+            } catch (Exception e) {
+                // If metadata isn't available, default to VARCHAR (safest/most common case)
+                p1Type = Types.VARCHAR;
+            }
+
+            // Bind param 1 as bytes or string depending on what the driver expects
+            if (p1Type == Types.BINARY || p1Type == Types.VARBINARY || p1Type == Types.LONGVARBINARY) {
+                if (idBytes == null && idStr != null) idBytes = idStr.getBytes("ISO-8859-1");
+                callStmt.setBytes(1, idBytes);
+            } else {
+                // VARCHAR, CHAR, or other character types
+                if (idStr == null && idBytes != null) idStr = new String(idBytes, "ISO-8859-1");
+                callStmt.setString(1, idStr);
+            }
+
             callStmt.setString(2, "QDOVEOUT  QTEMP     ISO-ISO..ENUBM0                           01");
             callStmt.registerOutParameter(3, Types.INTEGER);
             callStmt.registerOutParameter(4, Types.INTEGER);

--- a/src/main/java/com/github/ibm/mapepire/requests/DoVe.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/DoVe.java
@@ -77,7 +77,7 @@ public class DoVe extends BlockRetrievableRequest {
             }
         }
 
-        // Validate that we successfully retrieved the QQQDBVE identifier before proceeding
+        // Validate that it successfully retrieved the QQQDBVE identifier before proceeding
         if (idStr == null && idBytes == null) {
             throw new RuntimeException("Unable to locate QQQDBVE id in QTEMP.QDOVEOUT (QQRID=3014)");
         }
@@ -86,8 +86,8 @@ public class DoVe extends BlockRetrievableRequest {
                 "call QSYS.QQQDBVE(?,?,?,?)")) {
             // FIX: Detect the actual parameter type before binding to avoid "Data type mismatch" error.
             // The jt400 driver may describe QQQDBVE param 1 as VARCHAR or BINARY depending on
-            // translate-binary and other settings. Previously we always used setBytes(), which fails
-            // when the driver expects a character type. Now we check metadata and bind appropriately.
+            // translate-binary and other settings. Previously it used setBytes(), which fails
+            // when the driver expects a character type. Now we check the metadata first and bind it the right way.
             ParameterMetaData pmd = callStmt.getParameterMetaData();
             int p1Type = Types.OTHER;
             try {


### PR DESCRIPTION
Updated the DoVe.java to stop the "Data type mismatch". The code now looks at the parameter metadata to decide whether to bind the ID as a String or a byte array, which covers both ways the jt400 driver might describe it. It's a much more flexible way to handle the different driver configurations.