### PR TITLE
Add support fetching all rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The following request types are currently supported
 | `prepare_sql`         | Prepare SQL statement  | `sql`: the SQL statement <br/> `terse`: return data in terse format | 
 | `execute`         | Execute prepared SQL statement  | `cont_id`: the request ID of the previously-run `sql` or `prepare_sql` <br /> `parameters`: array parameter values corresponding to any parameter markers used. If `parameters` is an array of arrays, then the sql operations are executed as a batch. |   `data`: the data |
 | `prepare_sql_execute`         | Prepare and execute SQL statement  | `parameters`: array parameter values <br/> `terse`: return data in terse format |  `data`: the data |
-| `sqlmore`     | fetch more rows from a previous `sql`/`prepare_sql`/`prepare_sql_execute` request  | `cont_id`: the request ID of the previously-run `sql`/`prepare_sql`/`prepare_sql_execute` request <br/> `rows`: the maximum number of rows to return | `data`: the data <br/> `is_done`: whether all rows were fetched | 
+| `sqlmore`     | fetch more rows from a previous `sql`/`prepare_sql`/`prepare_sql_execute` request  | `cont_id`: the request ID of the previously-run `sql`/`prepare_sql`/`prepare_sql_execute` request <br/> `rows`: the maximum number of rows to return <br/> `allRows`: whether to return all rows | `data`: the data <br/> `is_done`: whether all rows were fetched | 
 | `sqlclose`     | close cursor from a previous `sql`/`prepare_sql`/`prepare_sql_execute` request  | `cont_id`: the request ID of the previously-run `sql`/`prepare_sql`/`prepare_sql_execute` request |  | 
 | `getdbjob`     | Get server job for database tasks  |  | `job`: the server job | 
 | `getversion`   | Get version info  |  | `build_date`: build date <br/> `version`: version | 

--- a/src/main/java/com/github/ibm/mapepire/Version.java
+++ b/src/main/java/com/github/ibm/mapepire/Version.java
@@ -1,5 +1,5 @@
 package com.github.ibm.mapepire;
 public class Version {
-      static public final String s_compileDateTime = "2024-08-08 00:36:20 (GMT)";
-      static public final String s_version = "2.0.0-rc1";
+      static public final String s_compileDateTime = "2026-04-18 18:35:05 (GMT)";
+      static public final String s_version = "2.3.5";
 }

--- a/src/main/java/com/github/ibm/mapepire/requests/RunSqlMore.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/RunSqlMore.java
@@ -15,7 +15,8 @@ public class RunSqlMore extends ClientRequest {
 
     @Override
     protected void go() throws Exception {
-        final int numRows = super.getRequestFieldInt("rows", 1000);
+        final boolean allRows = super.getRequestFieldBoolean("allRows", false);
+        final int numRows = allRows ? Integer.MAX_VALUE : super.getRequestFieldInt("rows", 1000);
         addReplyData("data", m_prev.getNextDataBlock(numRows));
         addReplyData("is_done", m_prev.isDone());
     }


### PR DESCRIPTION
The `sqlmore` request can now accept a `allRows` boolean parameter to retrieve all rows. This will be used by the database extension to support a `Retrieve All Rows` button similar to ACS RSS.

Associated change in the JS client: https://github.com/Mapepire-IBMi/mapepire-js/pull/69