### PR TITLE
Pr 145

### DIFF
--- a/ConnectionTraceContext.java
+++ b/ConnectionTraceContext.java
@@ -1,0 +1,4 @@
+// Updated file content for ConnectionTraceContext.java without ✅ emojis
+
+// NEW: Add new logging methods
+// FIXED: Corrected logging issue

--- a/src/main/java/com/github/ibm/mapepire/ConnectionTraceContext.java
+++ b/src/main/java/com/github/ibm/mapepire/ConnectionTraceContext.java
@@ -1,0 +1,235 @@
+package com.github.ibm.mapepire;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Manages per-connection trace contexts for daemon mode.
+ * Each WebSocket connection gets its own isolated trace buffer.
+ * 
+ * This ensures:
+ * - Per-connection log isolation (no cross-session log leakage)
+ * - Thread-safe trace operations in multi-client scenarios
+ * - Automatic cleanup of expired traces
+ * - Support for daemon mode tracing (previously disabled)
+ */
+public class ConnectionTraceContext {
+    
+    private static final ConcurrentHashMap<String, TraceBuffer> traceContexts = new ConcurrentHashMap<>();
+    private static final long DEFAULT_EXPIRY_TIME = 24 * 60 * 60 * 1000; // 24 hours
+    
+    /**
+     * Represents a per-connection trace buffer with isolated log entries.
+     */
+    public static class TraceBuffer {
+        private final Tracer.InMemCache<Tracer.Entry> buffer;
+        private final String connectionId;
+        private final long createdAt;
+        
+        /**
+         * Create a new trace buffer for a connection.
+         * 
+         * @param connectionId unique identifier for the connection
+         * @param bufferCapacity maximum number of trace entries to retain
+         */
+        public TraceBuffer(String connectionId, int bufferCapacity) {
+            this.connectionId = connectionId;
+            this.createdAt = System.currentTimeMillis();
+            this.buffer = new Tracer.InMemCache<>(bufferCapacity);
+        }
+        
+        /**
+         * Add a trace entry to this connection's buffer.
+         * 
+         * @param entry the trace entry to add
+         */
+        public synchronized void add(Tracer.Entry entry) {
+            buffer.add(entry);
+        }
+        
+        /**
+         * Get all trace entries as HTML.
+         * 
+         * @return formatted HTML containing all trace entries
+         */
+        public synchronized StringBuffer getAsHtml() {
+            StringBuffer buf = new StringBuffer();
+            buf.append("<html><body bgcolor=\"white\">\n\n");
+            buf.append("<h3>Connection: ").append(connectionId).append("</h3>\n");
+            buf.append("<p>Created: ").append(new java.util.Date(createdAt)).append("</p>\n");
+            
+            Collection<Tracer.Entry> entries = buffer.getEntries();
+            if (entries.isEmpty()) {
+                buf.append("<p><em>No trace entries</em></p>\n");
+            } else {
+                for (Tracer.Entry entry : entries) {
+                    buf.append(entry.asHtml());
+                    buf.append("\n");
+                }
+            }
+            
+            buf.append("</body></html>");
+            return buf;
+        }
+        
+        /**
+         * Get all trace entries as plain text (for debugging).
+         * 
+         * @return plain text containing all trace entries
+         */
+        public synchronized StringBuffer getAsPlainText() {
+            StringBuffer buf = new StringBuffer();
+            buf.append("Connection ID: ").append(connectionId).append("\n");
+            buf.append("Created: ").append(new java.util.Date(createdAt)).append("\n");
+            buf.append("=====================================\n");
+            
+            for (Tracer.Entry entry : buffer.getEntries()) {
+                buf.append("[").append(entry.getEventType()).append("] ");
+                buf.append(entry.getFormattedDate()).append(": ");
+                buf.append(entry.getDataAsString()).append("\n");
+            }
+            
+            return buf;
+        }
+        
+        /**
+         * Check if this trace buffer has expired.
+         * 
+         * @param maxAge maximum age in milliseconds
+         * @return true if buffer is older than maxAge
+         */
+        public boolean isExpired(long maxAge) {
+            return System.currentTimeMillis() - createdAt > maxAge;
+        }
+        
+        /**
+         * Get the connection ID for this trace buffer.
+         * 
+         * @return unique connection identifier
+         */
+        public String getConnectionId() {
+            return connectionId;
+        }
+        
+        /**
+         * Get the creation timestamp.
+         * 
+         * @return milliseconds since creation
+         */
+        public long getCreatedAt() {
+            return createdAt;
+        }
+    }
+    
+    /**
+     * Get or create a trace buffer for a specific connection.
+     * 
+     * @param connectionId unique identifier for the connection
+     * @return the trace buffer for this connection
+     */
+    public static TraceBuffer getOrCreate(String connectionId) {
+        return traceContexts.computeIfAbsent(connectionId, id -> 
+            new TraceBuffer(id, 100) // 100 entries per connection
+        );
+    }
+    
+    /**
+     * Get an existing trace buffer without creating one.
+     * 
+     * @param connectionId unique identifier for the connection
+     * @return the trace buffer, or null if it doesn't exist
+     */
+    public static TraceBuffer get(String connectionId) {
+        return traceContexts.get(connectionId);
+    }
+    
+    /**
+     * Remove and cleanup a trace buffer for a connection.
+     * 
+     * @param connectionId unique identifier for the connection
+     * @return the removed trace buffer, or null if it didn't exist
+     */
+    public static TraceBuffer remove(String connectionId) {
+        return traceContexts.remove(connectionId);
+    }
+    
+    /**
+     * Get trace data as HTML for a specific connection.
+     * 
+     * @param connectionId unique identifier for the connection
+     * @return HTML formatted trace data
+     */
+    public static StringBuffer getTraceDataAsHtml(String connectionId) {
+        TraceBuffer buffer = traceContexts.get(connectionId);
+        if (buffer == null) {
+            StringBuffer buf = new StringBuffer();
+            buf.append("<html><body bgcolor=\"white\">\n");
+            buf.append("<p><em>No trace data found for connection: ").append(connectionId).append("</em></p>\n");
+            buf.append("</body></html>");
+            return buf;
+        }
+        return buffer.getAsHtml();
+    }
+    
+    /**
+     * Get trace data as plain text for a specific connection.
+     * 
+     * @param connectionId unique identifier for the connection
+     * @return plain text formatted trace data
+     */
+    public static StringBuffer getTraceDataAsPlainText(String connectionId) {
+        TraceBuffer buffer = traceContexts.get(connectionId);
+        if (buffer == null) {
+            StringBuffer buf = new StringBuffer();
+            buf.append("No trace data found for connection: ").append(connectionId).append("\n");
+            return buf;
+        }
+        return buffer.getAsPlainText();
+    }
+    
+    /**
+     * Cleanup expired trace buffers to prevent memory leaks.
+     * Should be called periodically (e.g., every hour).
+     * 
+     * @return number of buffers cleaned up
+     */
+    public static int cleanup() {
+        return cleanup(DEFAULT_EXPIRY_TIME);
+    }
+    
+    /**
+     * Cleanup trace buffers older than maxAge.
+     * 
+     * @param maxAge maximum age in milliseconds for a buffer
+     * @return number of buffers cleaned up
+     */
+    public static int cleanup(long maxAge) {
+        int cleanedCount = 0;
+        for (String connectionId : traceContexts.keySet()) {
+            TraceBuffer buffer = traceContexts.get(connectionId);
+            if (buffer != null && buffer.isExpired(maxAge)) {
+                traceContexts.remove(connectionId);
+                cleanedCount++;
+                Tracer.info("Cleaned up expired trace buffer for connection: " + connectionId);
+            }
+        }
+        return cleanedCount;
+    }
+    
+    /**
+     * Get the number of active trace buffers.
+     * 
+     * @return count of active connections with trace data
+     */
+    public static int getActiveConnectionCount() {
+        return traceContexts.size();
+    }
+    
+    /**
+     * Clear all trace buffers (use with caution).
+     */
+    public static void clearAll() {
+        traceContexts.clear();
+    }
+}

--- a/src/main/java/com/github/ibm/mapepire/ConnectionTraceContext.java
+++ b/src/main/java/com/github/ibm/mapepire/ConnectionTraceContext.java
@@ -211,7 +211,7 @@ public class ConnectionTraceContext {
             if (buffer != null && buffer.isExpired(maxAge)) {
                 traceContexts.remove(connectionId);
                 cleanedCount++;
-                Tracer.info("Cleaned up expired trace buffer for connection: " + connectionId);
+                Tracer.globalInfo("Cleaned up expired trace buffer for connection: " + connectionId);
             }
         }
         return cleanedCount;

--- a/src/main/java/com/github/ibm/mapepire/SystemConnection.java
+++ b/src/main/java/com/github/ibm/mapepire/SystemConnection.java
@@ -100,6 +100,7 @@ public class SystemConnection {
     private final ClientSpecialRegisters m_clientRegs;
     private String m_applicationName;
     private final String clientAddress;
+    private final Tracer m_tracer;
 
     public SystemConnection() throws IOException {
         if (!MapepireServer.isSingleMode()) {
@@ -109,9 +110,10 @@ public class SystemConnection {
         this.m_clientRegs = clientRegs;
         this.clientAddress = clientRegs.getClientAddress();
         this.userProfile = System.getProperty("user.name");
+        this.m_tracer = Tracer.getGlobalTracer(); // Single mode uses global tracer
     }
 
-    public SystemConnection(String clientHost, String clientAddress, String host, String user, String pass) throws IOException {
+    public SystemConnection(String clientHost, String clientAddress, String host, String user, String pass, Tracer tracer) throws IOException {
         super();
         if (MapepireServer.isSingleMode()) {
             throw new IOException("Improper usage");
@@ -130,6 +132,7 @@ public class SystemConnection {
         this.password = pass;
         this.clientAddress = clientAddress;
         this.m_clientRegs = new ClientSpecialRegistersRemote(clientHost, clientAddress, user);
+        this.m_tracer = tracer; // Daemon mode uses per-connection tracer
     }
 
     public static boolean isRunningOnIBMi() {
@@ -154,7 +157,7 @@ public class SystemConnection {
             }
             return c.getClass().getMethod("getServerJobName").invoke(c).toString();
         } catch (Exception e) {
-            Tracer.err(e);
+            m_tracer.err(e);
             return "??????/??????/??????";
         }
     }
@@ -171,7 +174,7 @@ public class SystemConnection {
             try {
                 m_conn.close();
             } catch (SQLException e) {
-                Tracer.err(e);
+                m_tracer.err(e);
             }
             m_conn = null;
         }

--- a/src/main/java/com/github/ibm/mapepire/Tracer.java
+++ b/src/main/java/com/github/ibm/mapepire/Tracer.java
@@ -110,6 +110,17 @@ public class Tracer {
                 return "" + m_data;
             }
         }
+        public EventType getEventType() {
+            return m_type;
+        }
+
+        public String getFormattedDate() {
+            return getDateFormatter().format(m_date);
+        }
+
+        public String getDataAsString() {
+            return getRawTraceString();
+        }
     }
 
     private static Tracer s_instance = new Tracer();
@@ -156,7 +167,7 @@ public class Tracer {
         return s_dateFormatter = new SimpleDateFormat("yyyy-MM-dd'.'kk.mm.ss.SSS");
     }
 
-    private static class InMemCache<T> {
+    public static class InMemCache<T> {
         private final AtomicInteger m_ctr = new AtomicInteger(0);
         private final int m_capacity;
         private final LinkedHashMap<Integer, T> m_data;
@@ -195,6 +206,8 @@ public class Tracer {
     private TraceLevel m_traceLevel = TraceLevel.INPUT_AND_ERRORS;
     private TraceLevel m_jtOpenTraceLevel = TraceLevel.OFF;
     private Dest m_jtopenDest = Dest.IN_MEM;
+
+    private String m_connectionId = null; // ✅ NEW: For per-connection tracing in daemon mode
 
     private Tracer() {
         PrintWriter jt400PrintWriter = new PrintWriter(new Writer() {
@@ -242,18 +255,36 @@ public class Tracer {
         }
     }
 
-    public Tracer setTraceLevel(TraceLevel _l) {
-        if(!MapepireServer.isSingleMode()) {
-            return this;
-        }
-        m_traceLevel = _l;
+    /**
+    * Set the connection ID for per-connection tracing in daemon mode.
+    * ✅ NEW METHOD: Enables per-connection trace isolation
+    * 
+    * @param connectionId unique identifier for the connection
+    * @return this Tracer instance for method chaining
+    */
+    public Tracer setConnectionId(String connectionId) {
+        this.m_connectionId = connectionId;
         return this;
     }
 
+    /**
+    * Get the current connection ID.
+    * ✅ NEW METHOD
+    * 
+    * @return the connection ID, or null if not set
+    */
+    public String getConnectionId() {
+        return m_connectionId;
+    }
+
+    public Tracer setTraceLevel(TraceLevel _l) {
+    // ✅ FIXED: Allow tracing in daemon mode (removed single mode check)
+    m_traceLevel = _l;
+    return this;
+    }
+
     public Tracer setJtOpenTraceLevel(TraceLevel _l) {
-        if(!MapepireServer.isSingleMode()) {
-            return this;
-        }
+        // ✅ FIXED: Allow JtOpen tracing in daemon mode (removed single mode check)
         switch (_l) {
             case OFF:
                 Trace.setTraceOn(false);
@@ -280,9 +311,7 @@ public class Tracer {
     }
 
     public Tracer setDest(Dest _dest) {
-        if(!MapepireServer.isSingleMode()) {
-            return this;
-        }
+  // ✅ FIXED: Allow destination changes in daemon mode (removed single mode check)
         if (m_dest == _dest) {
             return this;
         }
@@ -299,9 +328,7 @@ public class Tracer {
     }
 
     public Tracer setJtOpenDest(Dest _dest) throws FileNotFoundException, UnsupportedEncodingException, IOException {
-        if(!MapepireServer.isSingleMode()) {
-            return this;
-        }
+       // ✅ FIXED: Allow destination changes in daemon mode (removed single mode check)
         if (m_jtopenDest == _dest) {
             return this;
         }
@@ -315,9 +342,7 @@ public class Tracer {
     }
 
     public String getDestString() throws IOException {
-        if(!MapepireServer.isSingleMode()) {
-            return "unknown";
-        }
+    // ✅ FIXED: Return actual destination instead of "unknown" in daemon mode
         switch (m_dest) {
             case FILE:
                 return getFile().getAbsolutePath();
@@ -329,9 +354,7 @@ public class Tracer {
     }
 
     public String getJtOpenDestString() throws IOException {
-        if(!MapepireServer.isSingleMode()) {
-            return "unknown";
-        }
+    // ✅ FIXED: Return actual destination instead of "unknown" in daemon mode
         switch (m_dest) {
             case FILE:
                 return getJtOpenFile().getAbsolutePath();
@@ -351,10 +374,13 @@ public class Tracer {
     }
 
     public StringBuffer getRawData() throws IOException {
-        if(!MapepireServer.isSingleMode()) {
-            return new StringBuffer("<prohibited>");
-        }
-        StringBuffer buf = new StringBuffer();
+        // ✅ FIXED: Support daemon mode per-connection trace retrieval
+        if (!MapepireServer.isSingleMode() && m_connectionId != null) {
+            return ConnectionTraceContext.getTraceDataAsHtml(m_connectionId);
+    }
+
+    // Single mode behavior (unchanged)
+    StringBuffer buf = new StringBuffer();
         if (Dest.IN_MEM == m_dest) {
             buf.append("<html><body bgcolor=\"white\">\n\n");
             synchronized (m_inMem) {
@@ -410,8 +436,18 @@ public class Tracer {
         if (!_t.isLoggedAt(m_traceLevel)) {
             return this;
         }
+
+        Entry entry = new Entry(_t, _data);
+
+        // ✅ NEW: Daemon mode - use per-connection context
+        if (!MapepireServer.isSingleMode() && m_connectionId != null) {
+            ConnectionTraceContext.getOrCreate(m_connectionId).add(entry);
+            return this;
+        }
+
+        // Existing single mode behavior
         if (Dest.IN_MEM == m_dest) {
-            m_inMem.add(new Entry(_t, _data));
+            m_inMem.add(entry);
             return this;
         }
         if (null == m_fileWriter) {

--- a/src/main/java/com/github/ibm/mapepire/Tracer.java
+++ b/src/main/java/com/github/ibm/mapepire/Tracer.java
@@ -136,28 +136,125 @@ public class Tracer {
         return new String(baos.toByteArray());
     }
 
-    public static Tracer get() {
+    /**
+     * Get the global Tracer instance for application-wide logging.
+     * For per-connection tracing in daemon mode, use getNew(String connectionId) instead.
+     *
+     * @return the global Tracer instance
+     */
+    public static Tracer getGlobalTracer() {
         return s_instance;
     }
 
+    /**
+     * @deprecated Use getGlobalTracer() instead for clarity
+     */
+    @Deprecated
+    public static Tracer get() {
+        return getGlobalTracer();
+    }
+
+    /**
+     * Create a new Tracer instance for per-connection tracing in daemon mode.
+     * This ensures trace isolation between different client connections.
+     *
+     * @param connectionId unique identifier for the connection
+     * @return a new Tracer instance configured for this connection
+     */
+    public static Tracer getNew(String connectionId) {
+        Tracer tracer = new Tracer();
+        tracer.m_connectionId = connectionId;
+        return tracer;
+    }
+
+    /**
+     * Log an info message to the global tracer.
+     * For per-connection logging, use the instance method on a connection-specific Tracer.
+     *
+     * @param _data the data to log
+     */
+    public static void globalInfo(Object _data) {
+        getGlobalTracer().Trace(EventType.INFO, _data);
+    }
+
+    /**
+     * @deprecated Use globalInfo() instead for clarity
+     */
+    @Deprecated
     public static void info(Object _data) {
-        get().Trace(EventType.INFO, _data);
+        globalInfo(_data);
     }
 
+    /**
+     * Log a warning message to the global tracer.
+     * For per-connection logging, use the instance method on a connection-specific Tracer.
+     *
+     * @param _data the data to log
+     */
+    public static void globalWarn(Object _data) {
+        getGlobalTracer().Trace(EventType.WARN, _data);
+    }
+
+    /**
+     * @deprecated Use globalWarn() instead for clarity
+     */
+    @Deprecated
     public static void warn(Object _data) {
-        get().Trace(EventType.WARN, _data);
+        globalWarn(_data);
     }
 
+    /**
+     * Log an error message to the global tracer.
+     * For per-connection logging, use the instance method on a connection-specific Tracer.
+     *
+     * @param _data the data to log
+     */
+    public static void globalErr(Object _data) {
+        getGlobalTracer().Trace(EventType.ERR, _data);
+    }
+
+    /**
+     * @deprecated Use globalErr() instead for clarity
+     */
+    @Deprecated
     public static void err(Object _data) {
-        get().Trace(EventType.ERR, _data);
+        globalErr(_data);
     }
 
+    /**
+     * Log incoming datastream to the global tracer.
+     * For per-connection logging, use the instance method on a connection-specific Tracer.
+     *
+     * @param _data the data to log
+     */
+    public static void globalDatastreamIn(Object _data) {
+        getGlobalTracer().Trace(EventType.DATASTREAM_IN, _data);
+    }
+
+    /**
+     * @deprecated Use globalDatastreamIn() instead for clarity
+     */
+    @Deprecated
     public static void datastreamIn(Object _data) {
-        get().Trace(EventType.DATASTREAM_IN, _data);
+        globalDatastreamIn(_data);
     }
 
+    /**
+     * Log outgoing datastream to the global tracer.
+     * For per-connection logging, use the instance method on a connection-specific Tracer.
+     *
+     * @param _data the data to log
+     */
+    public static void globalDatastreamOut(Object _data) {
+        getGlobalTracer().Trace(EventType.DATASTREAM_OUT, _data);
+    }
+
+    /**
+     * @deprecated Use globalDatastreamOut() instead for clarity
+     */
+    @Deprecated
     public static void datastreamOut(Object _data) {
-        get().Trace(EventType.DATASTREAM_OUT, _data);
+        globalDatastreamOut(_data);
     }
 
     private static DateFormat getDateFormatter() {
@@ -256,25 +353,62 @@ public class Tracer {
     }
 
     /**
-    * Set the connection ID for per-connection tracing in daemon mode.
-    * ✅ NEW METHOD: Enables per-connection trace isolation
-    * 
-    * @param connectionId unique identifier for the connection
-    * @return this Tracer instance for method chaining
-    */
-    public Tracer setConnectionId(String connectionId) {
-        this.m_connectionId = connectionId;
-        return this;
+     * Get the current connection ID for this Tracer instance.
+     *
+     * @return the connection ID, or null if this is the global tracer
+     */
+    public String getConnectionId() {
+        return m_connectionId;
     }
 
     /**
-    * Get the current connection ID.
-    * ✅ NEW METHOD
-    * 
-    * @return the connection ID, or null if not set
-    */
-    public String getConnectionId() {
-        return m_connectionId;
+     * Instance method to log info messages.
+     * Use this on connection-specific Tracer instances.
+     *
+     * @param _data the data to log
+     */
+    public void info(Object _data) {
+        Trace(EventType.INFO, _data);
+    }
+
+    /**
+     * Instance method to log warning messages.
+     * Use this on connection-specific Tracer instances.
+     *
+     * @param _data the data to log
+     */
+    public void warn(Object _data) {
+        Trace(EventType.WARN, _data);
+    }
+
+    /**
+     * Instance method to log error messages.
+     * Use this on connection-specific Tracer instances.
+     *
+     * @param _data the data to log
+     */
+    public void err(Object _data) {
+        Trace(EventType.ERR, _data);
+    }
+
+    /**
+     * Instance method to log incoming datastream.
+     * Use this on connection-specific Tracer instances.
+     *
+     * @param _data the data to log
+     */
+    public void datastreamIn(Object _data) {
+        Trace(EventType.DATASTREAM_IN, _data);
+    }
+
+    /**
+     * Instance method to log outgoing datastream.
+     * Use this on connection-specific Tracer instances.
+     *
+     * @param _data the data to log
+     */
+    public void datastreamOut(Object _data) {
+        Trace(EventType.DATASTREAM_OUT, _data);
     }
 
     public Tracer setTraceLevel(TraceLevel _l) {

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -1,30 +1,42 @@
 package com.github.ibm.mapepire.ws;
 
+import com.github.ibm.mapepire.ConnectionTraceContext;
 import com.github.ibm.mapepire.DataStreamProcessor;
 import com.github.ibm.mapepire.SystemConnection;
+import com.github.ibm.mapepire.Tracer;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.WebSocketAdapter;
 import org.eclipse.jetty.websocket.api.WebSocketException;
 
 import java.io.*;
 import java.nio.ByteBuffer;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
 public class DbWebsocketClient extends WebSocketAdapter {
   private final CountDownLatch closureLatch = new CountDownLatch(1);
   private final DataStreamProcessor io;
+  private final String connectionId; // ✅ NEW: Unique ID for per-connection tracing
 
   DbWebsocketClient(String clientHost, String clientAddress, String host, String user, String pass) throws IOException {
     super();
-    SystemConnection conn = new SystemConnection(clientHost, clientAddress,host, user, pass);
+    // ✅ NEW: Generate unique connection ID
+    this.connectionId = UUID.randomUUID().toString();
+    
+    SystemConnection conn = new SystemConnection(clientHost, clientAddress, host, user, pass);
     io = getDataStream(this, conn);
+    
+    // ✅ NEW: Initialize per-connection trace context
+    Tracer.get().setConnectionId(connectionId);
+    Tracer.info("WebSocket connection established: " + connectionId + 
+                " (Client: " + clientHost + ", User: " + user + ")");
   }
 
   @Override
   public void onWebSocketConnect(Session sess) {
     super.onWebSocketConnect(sess);
     sess.setIdleTimeout(Integer.MAX_VALUE);
-    System.out.println("Socket Connected: " + sess);
+    Tracer.info("Socket Connected: " + sess + " [Connection ID: " + connectionId + "]");
   }
 
   @Override
@@ -37,6 +49,13 @@ public class DbWebsocketClient extends WebSocketAdapter {
   public void onWebSocketClose(int statusCode, String reason) {
     io.end();
     super.onWebSocketClose(statusCode, reason);
+    
+    // ✅ NEW: Log connection closure
+    Tracer.info("WebSocket connection closed: " + connectionId + 
+                " (Status: " + statusCode + ", Reason: " + reason + ")");
+    
+    // ✅ NEW: Cleanup per-connection trace context
+    ConnectionTraceContext.remove(connectionId);
     closureLatch.countDown();
   }
 
@@ -44,7 +63,9 @@ public class DbWebsocketClient extends WebSocketAdapter {
   public void onWebSocketError(Throwable cause) {
     io.end();
     super.onWebSocketError(cause);
-    // cause.printStackTrace(System.err);
+    // ✅ NEW: Log error to per-connection trace
+    Tracer.err("WebSocket error on connection " + connectionId + ": " + cause.getMessage());
+    Tracer.err(cause);
   }
 
   public void awaitClosure() throws InterruptedException {
@@ -74,7 +95,7 @@ public class DbWebsocketClient extends WebSocketAdapter {
             try {
               endpoint.getRemote().sendString(message);
             } catch (WebSocketException e){
-              System.err.println("Could not send message due to error: " + e.getMessage());
+              Tracer.err("Could not send message on connection " + endpoint.connectionId + ": " + e.getMessage());
             }
           }
         }

--- a/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
+++ b/src/main/java/com/github/ibm/mapepire/ws/DbWebsocketClient.java
@@ -10,25 +10,30 @@ import org.eclipse.jetty.websocket.api.WebSocketException;
 
 import java.io.*;
 import java.nio.ByteBuffer;
-import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class DbWebsocketClient extends WebSocketAdapter {
+  private static final AtomicLong connectionIdGenerator = new AtomicLong(0);
+  
   private final CountDownLatch closureLatch = new CountDownLatch(1);
   private final DataStreamProcessor io;
-  private final String connectionId; // ✅ NEW: Unique ID for per-connection tracing
+  private final String connectionId;
+  private final Tracer tracer;
 
   DbWebsocketClient(String clientHost, String clientAddress, String host, String user, String pass) throws IOException {
     super();
-    // ✅ NEW: Generate unique connection ID
-    this.connectionId = UUID.randomUUID().toString();
+    // Generate unique connection ID using AtomicLong for better performance
+    this.connectionId = String.valueOf(connectionIdGenerator.incrementAndGet());
     
-    SystemConnection conn = new SystemConnection(clientHost, clientAddress, host, user, pass);
+    // Create per-connection tracer instance
+    this.tracer = Tracer.getNew(connectionId);
+    
+    SystemConnection conn = new SystemConnection(clientHost, clientAddress, host, user, pass, tracer);
     io = getDataStream(this, conn);
     
-    // ✅ NEW: Initialize per-connection trace context
-    Tracer.get().setConnectionId(connectionId);
-    Tracer.info("WebSocket connection established: " + connectionId + 
+    // Log connection establishment
+    tracer.info("WebSocket connection established: " + connectionId +
                 " (Client: " + clientHost + ", User: " + user + ")");
   }
 
@@ -36,7 +41,7 @@ public class DbWebsocketClient extends WebSocketAdapter {
   public void onWebSocketConnect(Session sess) {
     super.onWebSocketConnect(sess);
     sess.setIdleTimeout(Integer.MAX_VALUE);
-    Tracer.info("Socket Connected: " + sess + " [Connection ID: " + connectionId + "]");
+    tracer.info("Socket Connected: " + sess + " [Connection ID: " + connectionId + "]");
   }
 
   @Override
@@ -50,11 +55,11 @@ public class DbWebsocketClient extends WebSocketAdapter {
     io.end();
     super.onWebSocketClose(statusCode, reason);
     
-    // ✅ NEW: Log connection closure
-    Tracer.info("WebSocket connection closed: " + connectionId + 
+    // Log connection closure
+    tracer.info("WebSocket connection closed: " + connectionId +
                 " (Status: " + statusCode + ", Reason: " + reason + ")");
     
-    // ✅ NEW: Cleanup per-connection trace context
+    // Cleanup per-connection trace context
     ConnectionTraceContext.remove(connectionId);
     closureLatch.countDown();
   }
@@ -63,9 +68,9 @@ public class DbWebsocketClient extends WebSocketAdapter {
   public void onWebSocketError(Throwable cause) {
     io.end();
     super.onWebSocketError(cause);
-    // ✅ NEW: Log error to per-connection trace
-    Tracer.err("WebSocket error on connection " + connectionId + ": " + cause.getMessage());
-    Tracer.err(cause);
+    // Log error to per-connection trace
+    tracer.err("WebSocket error on connection " + connectionId + ": " + cause.getMessage());
+    tracer.err(cause);
   }
 
   public void awaitClosure() throws InterruptedException {
@@ -95,7 +100,7 @@ public class DbWebsocketClient extends WebSocketAdapter {
             try {
               endpoint.getRemote().sendString(message);
             } catch (WebSocketException e){
-              Tracer.err("Could not send message on connection " + endpoint.connectionId + ": " + e.getMessage());
+              endpoint.tracer.err("Could not send message on connection " + endpoint.connectionId + ": " + e.getMessage());
             }
           }
         }


### PR DESCRIPTION
Incorporated all the review comments.
Issues addressed:
1. Replace global singleton with per-connection Tracer instances via getNew()
2. Add getGlobalTracer() and globalInfo/Warn/Err() methods for clarity  
3. Replace UUID with AtomicLong for better performance
4. Make InMemCache public for ConnectionTraceContext usage
5. Update SystemConnection and DbWebsocketClient to use per-connection tracers.