### PR TITLE
fix(statements): close statements on close

### DIFF
--- a/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/BlockRetrievableRequest.java
@@ -150,6 +150,16 @@ public abstract class BlockRetrievableRequest extends ClientRequest {
         return m_isDone;
     }
 
+    protected void close() throws SQLException {
+        if (null != m_rs && !m_rs.isClosed()) {
+            final Statement stmt = m_rs.getStatement();
+            m_rs.close();
+            if (null != stmt && !stmt.isClosed()) {
+                stmt.close();
+            }
+        }
+    }
+
     protected Map<String, Object> getResultMetaDataForResponse() throws SQLException {
         return getResultMetaDataForResponse(this.m_rs.getMetaData(), getSystemConnection());
     }

--- a/src/main/java/com/github/ibm/mapepire/requests/CloseSqlCursor.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/CloseSqlCursor.java
@@ -1,7 +1,5 @@
 package com.github.ibm.mapepire.requests;
 
-import java.sql.ResultSet;
-
 import com.github.ibm.mapepire.ClientRequest;
 import com.github.ibm.mapepire.DataStreamProcessor;
 import com.google.gson.JsonObject;
@@ -17,13 +15,7 @@ public class CloseSqlCursor extends ClientRequest {
 
     @Override
     protected void go() throws Exception {
-        ResultSet rs = m_prev.m_rs;
-        if(null == rs) {
-            return;
-        }
-        if(!rs.isClosed()) {
-            rs.close();
-        }
+        m_prev.close();
     }
 
 }

--- a/src/main/java/com/github/ibm/mapepire/requests/PrepareSql.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/PrepareSql.java
@@ -35,7 +35,7 @@ public class PrepareSql extends BlockRetrievableRequest {
         }else {
             m_stmt = jdbcConn.prepareStatement(sql);
         }
-        
+
         final Map<String, Object> metaData = new LinkedHashMap<String, Object>();
 
         final ResultSetMetaData rsMetaData = m_stmt.getMetaData();
@@ -108,6 +108,18 @@ public class PrepareSql extends BlockRetrievableRequest {
     PreparedStatement getStatement() {
         return m_stmt;
     }
+
+    @Override
+    protected void close() throws SQLException {
+        // Closing the prepared statement also closes any open result set it owns.
+        // Without this, DML statements (m_rs == null) and paged result sets leak
+        // statement handles on the JDBC job, eventually causing
+        // "Limit on number of statements exceeded" (HY014, -99999).
+        if (null != m_stmt && !m_stmt.isClosed()) {
+            m_stmt.close();
+        }
+    }
+
     @Override
     public boolean isDone() {
         if(null != m_executeTask) {

--- a/src/main/java/com/github/ibm/mapepire/requests/RunSql.java
+++ b/src/main/java/com/github/ibm/mapepire/requests/RunSql.java
@@ -28,6 +28,11 @@ public class RunSql extends BlockRetrievableRequest {
             final List<Object> data = getNextDataBlock(numRows);
             addReplyData("data", data);
             addReplyData("is_done", isDone());
+        } else {
+            // No result set (DML/DDL): the statement is not reachable via m_rs and
+            // would otherwise never be closed, leaking statements on the JDBC job
+            // (eventually "Limit on number of statements exceeded", HY014, -99999).
+            stmt.close();
         }
     }
 }


### PR DESCRIPTION
### Summary
Long-lived connections (e.g. connection pools) eventually fail with:

```
Limit on number of statements exceeded., HY014, -99999
```

The server created JDBC `Statement`/`PreparedStatement` objects that were never closed on the normal client-driven close path. 

Each query permanently consumed a statement handle on the underlying `QZDASOINIT`/`QSQSRVR` job until the connection hit its statement-handle limit. 

Because it's a slow leak, it surfaced only after sustained traffic and looked intermittent. 

Under a small JVM heap it could also manifest earlier as an `OutOfMemoryError` (uncaught, since only `Exception` is handled), abruptly dropping client connections.

### Root cause
"Closing a query" only closed the cursor, not the owning statement. Two paths were affected:

**1. Prepared path (dominant) — `prepare_sql_execute` / `sqlclose`**
- `PrepareSql.go()` allocates `m_stmt = jdbcConn.prepareStatement(sql)` (or `prepareCall`).
- On close, the client sends `sqlclose` → `CloseSqlCursor`.
- The old `CloseSqlCursor.go()` closed only the `ResultSet`:
  - For **DML** (`m_rs == null`) it returned immediately → `PreparedStatement` leaked.
  - For **SELECT**, `rs.close()` closes the DB cursor but, per the JDBC spec, does **not** close the `Statement` → statement handle leaked.
- `DataStreamProcessor` then removes the entry from `m_prepStmtMap`, dropping the last reference to the `PrepareSql`, so nothing could ever close `m_stmt` (only GC finalization, far too late under load).

**2. Non-prepared path — `sql` (`RunSql`)**
- `RunSql.go()` created a `Statement` and, when the statement produced **no result set** (`hasRs == false`), never stored or closed it.
- The result-set case was only closed indirectly once the cursor was fully drained; an early `sqlclose` also leaked it.

Notably the leak was **not** visible in `QSYS2.OPEN_FILES` — the cursor got closed, only the JDBC statement handle leaked — so the only reliable symptom was the eventual `HY014`.

### Fix
Make "closing a query" release the **statement**, not just the cursor: