### PR TITLE
Generate `.tar.gz` for GitHub release

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -65,10 +65,11 @@ jobs:
         mv conf/iprules.conf staging/opt/mapepire/iprules.conf
         mv conf/iprules-single.conf staging/opt/mapepire/iprules-single.conf
 
-    - name: Create distribution .zip and move JAR file
+    - name: Create distribution .zip, .tar, and move JAR file
       run: |
         pushd staging/opt/mapepire
         zip -r ../../../mapepire-server-${{ env.project_version }}.zip bin lib iprules.conf iprules-single.conf
+        tar -czf ../../../mapepire-server-${{ env.project_version }}.tar.gz bin lib iprules.conf iprules-single.conf
         mv lib/mapepire/mapepire-server.jar ../../../mapepire-server.jar
         popd
 
@@ -79,6 +80,7 @@ jobs:
         name: v${{ env.project_version }}
         files: |
           mapepire-server-${{ env.project_version }}.zip
+          mapepire-server-${{ env.project_version }}.tar.gz
           mapepire-server.jar
 
     - name: Install NPM Dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.theprez</groupId>
     <artifactId>mapepire-server</artifactId>
-    <version>2.3.5</version>
+    <version>2.3.6</version>
     <name>Mapepire (IBM i) Server Component</name>
     <description>Server-side support for Mapepire cloud-native database access layer.</description>
     <url>https://github.com/Mapepire-IBMi/mapepire-server/</url>
@@ -216,5 +216,3 @@
     </dependencies>
 
 </project>
-
-


### PR DESCRIPTION
Related to https://github.ibm.com/ibmi-oss/rpm-specs/issues/2588

IBM i open source team would like to move away from using `unzip` in the RPM spec file so this PR also now generates a `.tar.gz` so we can move off using `unzip`.